### PR TITLE
update example of setting provider

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,13 +13,10 @@ description: |-
 ## Example Usage
 
 ```terraform
-# Configure the sendgrid provider using the required_providers stanza.
-# You may optionally use a version directive to prevent breaking
-# changes occurring unannounced.
 terraform {
   required_providers {
     hashicups = {
-      source = "registry.terraform.io/kenzo0107/sendgrid"
+      source = "kenzo0107/sendgrid"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,10 +1,7 @@
-# Configure the sendgrid provider using the required_providers stanza.
-# You may optionally use a version directive to prevent breaking
-# changes occurring unannounced.
 terraform {
   required_providers {
     hashicups = {
-      source = "registry.terraform.io/kenzo0107/sendgrid"
+      source = "kenzo0107/sendgrid"
     }
   }
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -71,7 +71,7 @@ func (p *sendgridProvider) Configure(ctx context.Context, req provider.Configure
 		apiKey = config.APIKey.ValueString()
 	}
 
-	if !config.APIKey.IsNull() {
+	if !config.Subuser.IsNull() {
 		subuser = config.Subuser.ValueString()
 	}
 


### PR DESCRIPTION
- update example of setting provider
- fix: unable to configure subuser for provider
  It was unable to set subuser of provider due to a setting mistake, so fix it.