### PR TITLE
Manage scopes of teamamte

### DIFF
--- a/docs/resources/teammate.md
+++ b/docs/resources/teammate.md
@@ -21,6 +21,13 @@ For more detailed information, please see the [SendGrid documentation](https://d
 ```terraform
 resource "sendgrid_teammate" "example" {
   email = "dummy@example.com"
+  scopes = [
+    "user.profile.read",
+  ]
+
+  lifecycle {
+    ignore_changes = [scopes]
+  }
 }
 ```
 
@@ -30,11 +37,19 @@ resource "sendgrid_teammate" "example" {
 ### Required
 
 - `email` (String) Teammate's email
+- `scopes` (Set of String) The permissions API Key has access to.
+
+For more detailed information, please see the [SendGrid documentation](https://docs.sendgrid.com/ui/account-and-settings/teammate-permissions#persona-scopes)
+
+Note:
+Since scopes are automatically added after registering the usernames of invited teammates, there's a possibility that they might differ from the values defined in the Terraform code.
+As some scopes that cannot be defined are unclear, the current approach is to use ignore_changes to avoid modifications and instead set permissions on the dashboard, which is preferable.
 
 ### Optional
 
-- `is_admin` (Boolean) Set to true if teammate has admin privileges
+- `is_admin` (Boolean) Set to true if teammate has admin privileges.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `username` (String) Teammate's username

--- a/examples/resources/sendgrid_teammate/resource.tf
+++ b/examples/resources/sendgrid_teammate/resource.tf
@@ -1,3 +1,10 @@
 resource "sendgrid_teammate" "example" {
   email = "dummy@example.com"
+  scopes = [
+    "user.profile.read",
+  ]
+
+  lifecycle {
+    ignore_changes = [scopes]
+  }
 }

--- a/internal/provider/teammate_data_source_test.go
+++ b/internal/provider/teammate_data_source_test.go
@@ -38,6 +38,7 @@ func testAccTeammateDataSourceConfig(email string) string {
 	return fmt.Sprintf(`
 resource "sendgrid_teammate" "test" {
 	email = "%[1]s"
+	scopes = ["user.profile.read"]
 }
 
 data "sendgrid_teammate" "test" {

--- a/internal/provider/teammate_resource_test.go
+++ b/internal/provider/teammate_resource_test.go
@@ -27,6 +27,7 @@ func TestAccTeammateResource(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "email", email),
 					resource.TestCheckResourceAttr(resourceName, "is_admin", "false"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "user.profile.read"),
 				),
 			},
 			// ImportState testing
@@ -42,6 +43,7 @@ func TestAccTeammateResource(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "email", email),
 					resource.TestCheckResourceAttr(resourceName, "is_admin", "true"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "user.profile.read"),
 				),
 			},
 		},
@@ -53,6 +55,7 @@ func testAccTeammateResourceConfig(email string, is_admin bool) string {
 resource "sendgrid_teammate" "test" {
 	email = "%s"
 	is_admin = %t
+	scopes = ["user.profile.read"]
 }
 `, email, is_admin)
 }


### PR DESCRIPTION
I had initially designed the specification to default to user.profile.read when scopes for a teammate were not specified, but It enables users to configure it themselves.

However, as the current specification for setting values in scopes is unclear and could lead to errors, we have included ignore_changes for scopes in the samples, making them exempt from modifications.