### PR TITLE
fix: unexpected new value: .scopes: was cty.SetValEmpty(cty.String), but now null in teammate import method

### DIFF
--- a/internal/provider/teammate_resource.go
+++ b/internal/provider/teammate_resource.go
@@ -392,7 +392,7 @@ func (r *teammateResource) ImportState(ctx context.Context, req resource.ImportS
 
 	// If the teammate is in a pending state, return their data.
 	if pendingTeammate != nil {
-		var scopes []types.String
+		scopes := []types.String{}
 		for _, s := range pendingTeammate.Scopes {
 			scopes = append(scopes, types.StringValue(s))
 		}
@@ -433,9 +433,9 @@ func (r *teammateResource) ImportState(ctx context.Context, req resource.ImportS
 		return
 	}
 
-	var scopesSet []types.String
+	scopes := []types.String{}
 	for _, s := range teammate.Scopes {
-		scopesSet = append(scopesSet, types.StringValue(s))
+		scopes = append(scopes, types.StringValue(s))
 	}
 
 	data = teammateResourceModel{
@@ -443,7 +443,7 @@ func (r *teammateResource) ImportState(ctx context.Context, req resource.ImportS
 		Email:    types.StringValue(teammate.Email),
 		IsAdmin:  types.BoolValue(teammate.IsAdmin),
 		Username: types.StringValue(teammate.Username),
-		Scopes:   scopesSet,
+		Scopes:   scopes,
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)


### PR DESCRIPTION
In teammate Import method,

After specifying .scopes = [] and applying, the following error occurs.

````
unexpected new value: .scopes: was cty.SetEmpty(cty.String), but now null.
````

This is because scopes is defined as `types.Set` type, so if it is not specified, it is specified as the default value.

To avoid the above, define .scopes with `[]types.String` type, Specify the default with `[]types.String{}`.