### PR TITLE
Retry when rate limit occurs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework v1.3.5
 	github.com/hashicorp/terraform-plugin-go v0.18.0
 	github.com/hashicorp/terraform-plugin-testing v1.5.1
-	github.com/kenzo0107/sendgrid v1.0.0
+	github.com/kenzo0107/sendgrid v1.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/kenzo0107/sendgrid v0.0.21 h1:78rEdM+lNI/yK6ZBrgfP1/6g2X4227lCRHMM+8f
 github.com/kenzo0107/sendgrid v0.0.21/go.mod h1:QjjiRx0jvq2ldgR7U9pnoW+F3wf/E9pVUed04pReuPU=
 github.com/kenzo0107/sendgrid v1.0.0 h1:WaKt9qp5jEoj3CuhLV8SG8c9h7MZVkLn1qjC2WQpWyI=
 github.com/kenzo0107/sendgrid v1.0.0/go.mod h1:QjjiRx0jvq2ldgR7U9pnoW+F3wf/E9pVUed04pReuPU=
+github.com/kenzo0107/sendgrid v1.0.1 h1:6nkrV0hRkPqS7P177JYFaVbSa5CVNbW6ZSJ8mF0yst8=
+github.com/kenzo0107/sendgrid v1.0.1/go.mod h1:QjjiRx0jvq2ldgR7U9pnoW+F3wf/E9pVUed04pReuPU=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=

--- a/internal/provider/api_key_resource_test.go
+++ b/internal/provider/api_key_resource_test.go
@@ -12,9 +12,6 @@ import (
 )
 
 func TestAccAPIKeyResource(t *testing.T) {
-	// NOTE: It skips the test because the resource creation process is error-prone and the test completes successfully in the local environment without any issues.
-	t.Skip()
-
 	resourceName := "sendgrid_api_key.test"
 
 	name := fmt.Sprintf("test-acc-%s", acctest.RandString(16))

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"os"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -13,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/kenzo0107/sendgrid"
 )
 
@@ -159,4 +161,22 @@ func New(version string) func() provider.Provider {
 			version: version,
 		}
 	}
+}
+
+func retryOnRateLimit(ctx context.Context, f func() (interface{}, error)) (resp interface{}, err error) {
+	for retry := 0; retry < 3; retry++ {
+		resp, err = f()
+		if err == nil {
+			break
+		}
+		if rle, ok := err.(*sendgrid.RateLimitedError); ok {
+			tflog.Info(ctx, "Rate limited, retrying after", map[string]interface{}{
+				"retryAfter (sec)": rle.RetryAfter.Seconds(),
+			})
+			// Sleep for the duration of the rate limit and try again.
+			time.Sleep(rle.RetryAfter)
+			continue
+		}
+	}
+	return resp, err
 }

--- a/internal/provider/subuser_resource_test.go
+++ b/internal/provider/subuser_resource_test.go
@@ -13,9 +13,6 @@ import (
 )
 
 func TestAccSubuserResource(t *testing.T) {
-	// NOTE: It skips the test because the resource creation process is error-prone and the test completes successfully in the local environment without any issues.
-	t.Skip()
-
 	resourceName := "sendgrid_subuser.test"
 
 	ipAddressAllowed := os.Getenv("IP_ADDRESS")

--- a/internal/provider/teammate_resource_test.go
+++ b/internal/provider/teammate_resource_test.go
@@ -12,9 +12,6 @@ import (
 )
 
 func TestAccTeammateResource(t *testing.T) {
-	// NOTE: It skips the test because the resource creation process is error-prone and the test completes successfully in the local environment without any issues.
-	t.Skip()
-
 	resourceName := "sendgrid_teammate.test"
 
 	email := fmt.Sprintf("test-acc-%s@example.com", acctest.RandString(16))


### PR DESCRIPTION
Do not re-execute on the library [kenzo0107/sendgrid](https://github.com/kenzo0107/sendgrid) side when rate limit occurs, Re-execute on the provider side.