### PR TITLE
docs: Correct import instructions for sendgrid_teammate resource

### DIFF
--- a/docs/resources/teammate.md
+++ b/docs/resources/teammate.md
@@ -53,3 +53,11 @@ As some scopes that cannot be defined are unclear, the current approach is to us
 
 - `id` (String) The ID of this resource.
 - `username` (String) Teammate's username
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+% terraform import sendgrid_teammate.example <teammate's email>
+```

--- a/examples/resources/sendgrid_teammate/import.sh
+++ b/examples/resources/sendgrid_teammate/import.sh
@@ -1,0 +1,1 @@
+% terraform import sendgrid_teammate.example <teammate's email>


### PR DESCRIPTION
This PR adds the import instructions for the sendgrid_teammate resource in the project's documentation.