### PR TITLE
Add default permission sender_verification_eligible for API Key

### DIFF
--- a/internal/provider/api_key_data_source_test.go
+++ b/internal/provider/api_key_data_source_test.go
@@ -29,6 +29,7 @@ func TestAccAPIKeyDataSource(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "user.profile.read"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "2fa_required"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "sender_verification_exempt"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "sender_verification_eligible"),
 				),
 			},
 		},
@@ -43,6 +44,7 @@ resource "sendgrid_api_key" "test" {
 		"user.profile.read",
 		"2fa_required",
 		"sender_verification_exempt",
+		"sender_verification_eligible",
 	]
 }
 

--- a/internal/provider/api_key_resource_test.go
+++ b/internal/provider/api_key_resource_test.go
@@ -49,6 +49,7 @@ func TestAccAPIKeyResource(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "user.profile.read"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "2fa_required"),
 					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "sender_verification_exempt"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "sender_verification_eligible"),
 					resource.TestCheckResourceAttrSet(resourceName, "api_key"),
 				),
 			},
@@ -64,6 +65,7 @@ resource "sendgrid_api_key" "test" {
 		"user.profile.read",
 		"2fa_required",
 		"sender_verification_exempt",
+		"sender_verification_eligible",
 	]
 }
 `, name)


### PR DESCRIPTION
Consider that API Key permissions include sender_verification_eligible which is added by default.