### PR TITLE
Upgrade goreleaser version 2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
 before:
@@ -54,7 +56,3 @@ release:
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
-  # If you want to manually examine the release before its live, uncomment this line:
-  # draft: true
-changelog:
-  skip: true


### PR DESCRIPTION
fix the error below:

```
/opt/hostedtoolcache/goreleaser-action/2.0.0/x64/goreleaser release --clean
  • starting release...
  • only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
  ⨯ release failed after 0s                  error=only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.0.0/x64/goreleaser' failed with exit code 1
```