### PR TITLE
fix: Unable to change API Key permissions

### DIFF
--- a/internal/provider/api_key_resource.go
+++ b/internal/provider/api_key_resource.go
@@ -191,15 +191,13 @@ func (r *apiKeyResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	var scopes []string
 	if !reflect.DeepEqual(data.Scopes, state.Scopes) {
-		for _, e := range data.Scopes.Elements() {
-			scopes = append(scopes, e.String())
-		}
+		scopes = flex.ExpandFrameworkStringSet(ctx, data.Scopes)
 	}
 
 	data.ID = types.StringValue(id)
 	data.APIKey = state.APIKey
 
-	if scopes != nil {
+	if len(scopes) > 0 {
 		// update name and scopes
 		o, err := r.client.UpdateAPIKeyNameAndScopes(ctx, id, &sendgrid.InputUpdateAPIKeyNameAndScopes{
 			Name:   data.Name.ValueString(),


### PR DESCRIPTION
issue: https://github.com/kenzo0107/terraform-provider-sendgrid/issues/98

The following error occurs when updating API Key permissions.

```
Plan: 0 to add, 1 to change, 0 to destroy.
sendgrid_api_key.dev: Modifying... [id=#####]
╷
│ Error: Updating api key
│
│   with sendgrid_api_key.xxx,
│   on sendgrid.tf line 7, in resource "sendgrid_api_key" "xxx":
│    7: resource "sendgrid_api_key" "xxx" {
│
│ Unable to update api key's permissions and name, got error: message:
│ unauthorized scopes: ...
```

The permission string has " before and after it, so trim it to resolve the issue.