### PR TITLE
Sendgrid api_keys endpoint does not return the updated scopes list

### DIFF
--- a/internal/provider/api_key_resource.go
+++ b/internal/provider/api_key_resource.go
@@ -210,7 +210,8 @@ func (r *apiKeyResource) Update(ctx context.Context, req resource.UpdateRequest,
 			)
 			return
 		}
-		s, d := types.SetValueFrom(ctx, types.StringType, o.Scopes)
+		data.Name = types.StringValue(o.Name)
+		s, d := types.SetValueFrom(ctx, types.StringType, scopes)
 		data.Scopes = s
 		resp.Diagnostics.Append(d...)
 	} else {


### PR DESCRIPTION
When trying to update an api_key scopes, the terraform apply fails with the following error:
```
╷
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to
│ module.my_mod.sendgrid_api_key.email_sender["my-key"],
│ provider
│ "provider[\"registry.terraform.io/kenzo0107/sendgrid\"].my-account"
│ produced an unexpected new value: .scopes: was
│ cty.SetVal([]cty.Value{cty.StringVal("mail.send")}), but now null.
│ 
│ This is a bug in the provider, which should be reported in the provider's
│ own issue tracker.
╵
```
These because the `PUT https://api.sendgrid.com/v3/api_keys/id` does not return the list of scopes.

Twillo documentation is very confusing in regard to it because the schema does not contain `scopes` while the Example does it: https://www.twilio.com/docs/sendgrid/api-reference/api-keys/update-api-key-name-and-scopes#responses

In conclusion, if the sengrid api does not return scopes there ain't much else we can do in the terraform provider.