### PR TITLE
Change how teammate scopes are managed

### DIFF
--- a/docs/resources/teammate.md
+++ b/docs/resources/teammate.md
@@ -23,11 +23,17 @@ resource "sendgrid_teammate" "example" {
   email = "dummy@example.com"
   scopes = [
     "user.profile.read",
+    "mail_settings.read",
+    "partner_settings.read",
+    "tracking_settings.read",
+    "user.account.read",
+    "user.credits.read",
+    "user.email.read",
+    "user.profile.update",
+    "user.settings.enforced_tls.read",
+    "user.timezone.read",
+    "user.username.read",
   ]
-
-  lifecycle {
-    ignore_changes = [scopes]
-  }
 }
 ```
 
@@ -41,9 +47,14 @@ resource "sendgrid_teammate" "example" {
 
 For more detailed information, please see the [SendGrid documentation](https://docs.sendgrid.com/ui/account-and-settings/teammate-permissions#persona-scopes)
 
-Note:
-Since scopes are automatically added after registering the usernames of invited teammates, there's a possibility that they might differ from the values defined in the Terraform code.
-As some scopes that cannot be defined are unclear, the current approach is to use ignore_changes to avoid modifications and instead set permissions on the dashboard, which is preferable.
+The following Scopes are set automatically by SendGrid, so they cannot be set manually:
+
+- 2fa_exempt
+- 2fa_required
+- sender_verification_exempt
+- sender_verification_eligible
+
+A teammate remains in a pending state until the invitation is accepted, during which scopes cannot be modified.
 
 ### Optional
 

--- a/examples/resources/sendgrid_teammate/resource.tf
+++ b/examples/resources/sendgrid_teammate/resource.tf
@@ -2,9 +2,15 @@ resource "sendgrid_teammate" "example" {
   email = "dummy@example.com"
   scopes = [
     "user.profile.read",
+    "mail_settings.read",
+    "partner_settings.read",
+    "tracking_settings.read",
+    "user.account.read",
+    "user.credits.read",
+    "user.email.read",
+    "user.profile.update",
+    "user.settings.enforced_tls.read",
+    "user.timezone.read",
+    "user.username.read",
   ]
-
-  lifecycle {
-    ignore_changes = [scopes]
-  }
 }

--- a/internal/provider/teammate_resource_test.go
+++ b/internal/provider/teammate_resource_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -22,7 +23,7 @@ func TestAccTeammateResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccTeammateResourceConfig(email, false),
+				Config: testAccTeammateResourceConfig(email, []string{"user.profile.read"}),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "email", email),
@@ -36,26 +37,18 @@ func TestAccTeammateResource(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			// Update and Read testing
-			{
-				Config: testAccTeammateResourceConfig(email, true),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "email", email),
-					resource.TestCheckResourceAttr(resourceName, "is_admin", "true"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "user.profile.read"),
-				),
-			},
 		},
 	})
 }
 
-func testAccTeammateResourceConfig(email string, is_admin bool) string {
+func testAccTeammateResourceConfig(email string, scopes []string) string {
+	for i, s := range scopes {
+		scopes[i] = `"` + s + `"`
+	}
 	return fmt.Sprintf(`
 resource "sendgrid_teammate" "test" {
 	email = "%s"
-	is_admin = %t
-	scopes = ["user.profile.read"]
+	scopes = [%s]
 }
-`, email, is_admin)
+`, email, strings.Join(scopes, ", "))
 }


### PR DESCRIPTION
- Treat auto-assigned scopes as unmanaged by SendGrid
    - 2fa_exempt
    - 2fa_required
    - sender_verification_exempt
    - sender_verification_eligible
- Add validation to prevent invalid or silently ignored scopes
- Manage admin teammates with empty scope lists since they have all scopes by default
- Remove teammate update test since scopes can't be modified while pending invitation
- Update documents about teammate scopes
  - A teammate remains in a pending state until the invitation is accepted, during which scopes cannot be modified.