### PR TITLE
Change how API Key scopes are managed

### DIFF
--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -23,9 +23,6 @@ resource "sendgrid_api_key" "example" {
   name = "dummy"
   scopes = [
     "user.profile.read",
-    "sender_verification_exempt",
-    "sender_verification_eligible",
-    "2fa_required",
   ]
 }
 ```
@@ -39,7 +36,13 @@ resource "sendgrid_api_key" "example" {
 
 ### Optional
 
-- `scopes` (Set of String) The permissions API Key has access to
+- `scopes` (Set of String) The permissions API Key has access to.
+
+The following Scopes are set automatically by SendGrid, so they cannot be set manually:
+
+- sender_verification_exempt
+- sender_verification_eligible
+- 2fa_required
 
 ### Read-Only
 

--- a/examples/resources/sendgrid_api_key/resource.tf
+++ b/examples/resources/sendgrid_api_key/resource.tf
@@ -2,8 +2,5 @@ resource "sendgrid_api_key" "example" {
   name = "dummy"
   scopes = [
     "user.profile.read",
-    "sender_verification_exempt",
-    "sender_verification_eligible",
-    "2fa_required",
   ]
 }

--- a/flex/set.go
+++ b/flex/set.go
@@ -19,19 +19,3 @@ func ExpandFrameworkStringSet(ctx context.Context, set types.Set) []string {
 
 	return vs
 }
-
-func ContainsAll(targets []string, items []string) bool {
-	// Convert items to a map for faster lookup
-	itemSet := make(map[string]bool)
-	for _, item := range items {
-		itemSet[item] = true
-	}
-
-	// Check if each target exists in the itemSet
-	for _, target := range targets {
-		if !itemSet[target] {
-			return false
-		}
-	}
-	return true
-}

--- a/internal/provider/api_key_data_source_test.go
+++ b/internal/provider/api_key_data_source_test.go
@@ -27,9 +27,6 @@ func TestAccAPIKeyDataSource(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "user.profile.read"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "2fa_required"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "sender_verification_exempt"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "sender_verification_eligible"),
 				),
 			},
 		},
@@ -42,9 +39,6 @@ resource "sendgrid_api_key" "test" {
 	name = "%s"
 	scopes = [
 		"user.profile.read",
-		"2fa_required",
-		"sender_verification_exempt",
-		"sender_verification_eligible",
 	]
 }
 

--- a/internal/provider/api_key_resource_test.go
+++ b/internal/provider/api_key_resource_test.go
@@ -28,9 +28,6 @@ func TestAccAPIKeyResource(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "user.profile.read"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "2fa_required"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "sender_verification_exempt"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "sender_verification_eligible"),
 					resource.TestCheckResourceAttrSet(resourceName, "api_key"),
 				),
 			},
@@ -48,9 +45,6 @@ func TestAccAPIKeyResource(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "name", nameUpdated),
 					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "user.profile.read"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "2fa_required"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "sender_verification_exempt"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "scopes.*", "sender_verification_eligible"),
 					resource.TestCheckResourceAttrSet(resourceName, "api_key"),
 				),
 			},
@@ -64,9 +58,6 @@ resource "sendgrid_api_key" "test" {
 	name = "%s"
 	scopes = [
 		"user.profile.read",
-		"2fa_required",
-		"sender_verification_exempt",
-		"sender_verification_eligible",
 	]
 }
 `, name)


### PR DESCRIPTION
- Treat auto-assigned scopes as unmanaged by SendGrid
  - sender_verification_exempt
  - sender_verification_eligible
  - 2fa_required
- Update documents about API Key scopes