### PR TITLE
Fix SSO deletion and import to use email instead of username 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.28.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.2
-	github.com/kenzo0107/sendgrid v1.4.1
+	github.com/kenzo0107/sendgrid v1.5.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
 github.com/jhump/protoreflect v1.15.1/go.mod h1:jD/2GMKKE6OqX8qTjhADU1e6DShO+gavG9e0Q693nKo=
-github.com/kenzo0107/sendgrid v1.4.1 h1:5fyF5H+AGnH9mjrBfsBad1oTCsasGIBSFv0kl5S/nLU=
-github.com/kenzo0107/sendgrid v1.4.1/go.mod h1:o93EmGpbWbhaxLoiGB+x6g3tLof7TwbUlzjHNLvpDP8=
+github.com/kenzo0107/sendgrid v1.5.0 h1:/MAHecz6x5iT7ildvGJnXbvxkL7gxcgXHwicNlwCPfk=
+github.com/kenzo0107/sendgrid v1.5.0/go.mod h1:o93EmGpbWbhaxLoiGB+x6g3tLof7TwbUlzjHNLvpDP8=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/internal/provider/teammate_model.go
+++ b/internal/provider/teammate_model.go
@@ -27,7 +27,10 @@ func pendingTeammateByEmail(ctx context.Context, client *sendgrid.Client, email 
 }
 
 func getTeammateByEmail(ctx context.Context, client *sendgrid.Client, email string) (*sendgrid.Teammate, error) {
-	r, err := client.GetTeammates(ctx)
+	// NOTE: When retrieving a list of teammates that exceeds the default fetch limit,
+	//       we need to implement pagination using `limit` and `offset`.
+	//       In that case, you should redesign the logic with performance in mind.
+	r, err := client.GetTeammates(ctx, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This resolves https://github.com/kenzo0107/terraform-provider-sendgrid/issues/119.

SSO deletion was failing due to incorrect use of username. Updated the logic to use email, which corresponds to the teammate ID.

Also updated the import logic to use email for simpler and more accurate processing.