### PR TITLE
Improve scope handling for admin and SSO teammates

### DIFF
--- a/docs/resources/sso_teammate.md
+++ b/docs/resources/sso_teammate.md
@@ -39,7 +39,7 @@ resource "sendgrid_sso_teammate" "example" {
 ### Optional
 
 - `is_admin` (Boolean) Set to true if teammate has admin privileges.
-- `scopes` (Set of String) Add or remove permissions from a Teammate using this scopes property. See [Teammate Permissions](https://www.twilio.com/docs/sendgrid/ui/account-and-settings/teammate-permissions) for a complete list of available scopes. You should not include this propety in the request when setting the `is_admin` property to `true` or `subuser_access` property to a list of subuser accesses.
+- `scopes` (Set of String) Add or remove permissions from a Teammate using this scopes property. See [Teammate Permissions](https://www.twilio.com/docs/sendgrid/ui/account-and-settings/teammate-permissions) for a complete list of available scopes. You should not include this propety in the request when setting the `is_admin` property to `true` or `subuser_access` property to a list of subuser accesses. The following Scopes are set automatically by SendGrid, so they cannot be set manually:`2fa_exempt`, `2fa_required`, `sender_verification_exempt`, `sender_verification_eligible`
 - `subuser_access` (Attributes List) Specify which Subusers the Teammate may access and act on behalf of. (see [below for nested schema](#nestedatt--subuser_access))
 
 ### Read-Only

--- a/docs/resources/teammate.md
+++ b/docs/resources/teammate.md
@@ -47,14 +47,7 @@ resource "sendgrid_teammate" "example" {
 
 For more detailed information, please see the [SendGrid documentation](https://docs.sendgrid.com/ui/account-and-settings/teammate-permissions#persona-scopes)
 
-The following Scopes are set automatically by SendGrid, so they cannot be set manually:
-
-- 2fa_exempt
-- 2fa_required
-- sender_verification_exempt
-- sender_verification_eligible
-
-A teammate remains in a pending state until the invitation is accepted, during which scopes cannot be modified.
+The following Scopes are set automatically by SendGrid, so they cannot be set manually:`2fa_exempt`, `2fa_required`, `sender_verification_exempt`, `sender_verification_eligible`. A teammate remains in a pending state until the invitation is accepted, during which scopes cannot be modified.
 
 ### Optional
 

--- a/flex/set.go
+++ b/flex/set.go
@@ -2,6 +2,8 @@ package flex
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -18,4 +20,12 @@ func ExpandFrameworkStringSet(ctx context.Context, set types.Set) []string {
 	}
 
 	return vs
+}
+
+func QuoteAndJoin(items []string) string {
+	var quoted []string
+	for _, v := range items {
+		quoted = append(quoted, fmt.Sprintf("`%s`", v))
+	}
+	return strings.Join(quoted, ", ")
 }


### PR DESCRIPTION
Add validation to ensure admin users have non-empty scopes when creating or updating teammate/SSO teammate resources, preventing misconfiguration.

Also allow managing SSO teammates without auto-added scopes from SendGrid, and update documentation to reflect the `autoScopes` setting.