### PR TITLE
Upgrade sendgrid to v1.7.0 and add webhook signing support

### DIFF
--- a/docs/data-sources/event_webhook.md
+++ b/docs/data-sources/event_webhook.md
@@ -43,6 +43,8 @@ data "sendgrid_event_webhook" "example" {
 - `oauth_token_url` (String) Set this property to the URL where SendGrid will send the OAuth client ID and client secret to generate an OAuth access token. This should be your OAuth server or service provider. When passing data in this field, you must also include the oauth_client_id property.
 - `open` (Boolean) Set this property to true to receive open events. Open events occur when a recipient has opened the HTML message. You must enable Open Tracking to receive this type of event.
 - `processed` (Boolean) Set this property to true to receive processed events. Processed events occur when a message has been received by Twilio SendGrid and the message is ready to be delivered.
+- `public_key` (String) The public key used to verify webhook signatures. This field is populated when signature verification is enabled.
+- `signed` (Boolean) Indicates whether signature verification is enabled for the Event Webhook. When enabled, SendGrid signs webhook payloads with a private key.
 - `spam_report` (Boolean) Set this property to true to receive spam report events. Spam reports occur when recipients mark a message as spam.
 - `unsubscribe` (Boolean) Set this property to true to receive unsubscribe events. Unsubscribes occur when recipients click on a message's subscription management link. You must enable Subscription Tracking to receive this type of event.
 - `url` (String) Set this property to the URL where you want the Event Webhook to send event data.

--- a/docs/resources/event_webhook.md
+++ b/docs/resources/event_webhook.md
@@ -16,7 +16,14 @@ Because the Event Webhook delivers data to your systems, it is also well-suited 
 
 ```terraform
 resource "sendgrid_event_webhook" "example" {
-  url = "https://example.com"
+  url           = "https://example.com"
+  enabled       = true
+  signed        = true
+  delivered     = true
+  processed     = true
+  bounce        = true
+  dropped       = true
+  friendly_name = "Example Event Webhook"
 }
 ```
 
@@ -43,9 +50,11 @@ resource "sendgrid_event_webhook" "example" {
 - `oauth_token_url` (String) Set this property to the URL where SendGrid will send the OAuth client ID and client secret to generate an OAuth access token. This should be your OAuth server or service provider. When passing data in this field, you must also include the oauth_client_id property.
 - `open` (Boolean) Set this property to true to receive open events. Open events occur when a recipient has opened the HTML message. You must enable Open Tracking to receive this type of event. (Default: `false`)
 - `processed` (Boolean) Set this property to true to receive processed events. Processed events occur when a message has been received by Twilio SendGrid and the message is ready to be delivered. (Default: `false`)
+- `signed` (Boolean) Set this property to true to enable signature verification for the Event Webhook. When enabled, SendGrid will sign webhook payloads with a private key and include a signature in the request headers. (Default: `false`)
 - `spam_report` (Boolean) Set this property to true to receive spam report events. Spam reports occur when recipients mark a message as spam. (Default: `false`)
 - `unsubscribe` (Boolean) Set this property to true to receive unsubscribe events. Unsubscribes occur when recipients click on a message's subscription management link. You must enable Subscription Tracking to receive this type of event. (Default: `false`)
 
 ### Read-Only
 
 - `id` (String) The ID of Event Webhook
+- `public_key` (String) The public key used to verify webhook signatures. This is automatically generated when signature verification is enabled and is read-only.

--- a/examples/resources/sendgrid_event_webhook/resource.tf
+++ b/examples/resources/sendgrid_event_webhook/resource.tf
@@ -1,3 +1,10 @@
 resource "sendgrid_event_webhook" "example" {
-  url = "https://example.com"
+  url           = "https://example.com"
+  enabled       = true
+  signed        = true
+  delivered     = true
+  processed     = true
+  bounce        = true
+  dropped       = true
+  friendly_name = "Example Event Webhook"
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.28.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.2
-	github.com/kenzo0107/sendgrid v1.6.0
+	github.com/kenzo0107/sendgrid v1.7.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
 github.com/jhump/protoreflect v1.15.1/go.mod h1:jD/2GMKKE6OqX8qTjhADU1e6DShO+gavG9e0Q693nKo=
-github.com/kenzo0107/sendgrid v1.6.0 h1:E+xXzG6Y+6hpvFuxyKihST8WBPsF6ue/vF2GGUBcxHg=
-github.com/kenzo0107/sendgrid v1.6.0/go.mod h1:o93EmGpbWbhaxLoiGB+x6g3tLof7TwbUlzjHNLvpDP8=
+github.com/kenzo0107/sendgrid v1.7.0 h1:ZaPwWcjR3EE974qsrkCgFFYmQq2hE9Y4jRfp4qR7JVc=
+github.com/kenzo0107/sendgrid v1.7.0/go.mod h1:o93EmGpbWbhaxLoiGB+x6g3tLof7TwbUlzjHNLvpDP8=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/internal/provider/event_webhook_data_source.go
+++ b/internal/provider/event_webhook_data_source.go
@@ -43,6 +43,8 @@ type eventWebhookDataSourceModel struct {
 	OAuthClientID     types.String `tfsdk:"oauth_client_id"`
 	OAuthClientSecret types.String `tfsdk:"oauth_client_secret"`
 	OAuthTokenURL     types.String `tfsdk:"oauth_token_url"`
+	Signed            types.Bool   `tfsdk:"signed"`
+	PublicKey         types.String `tfsdk:"public_key"`
 }
 
 func (d *eventWebhookDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -147,6 +149,14 @@ Because the Event Webhook delivers data to your systems, it is also well-suited 
 				MarkdownDescription: "Set this property to the URL where SendGrid will send the OAuth client ID and client secret to generate an OAuth access token. This should be your OAuth server or service provider. When passing data in this field, you must also include the oauth_client_id property.",
 				Computed:            true,
 			},
+			"signed": schema.BoolAttribute{
+				MarkdownDescription: "Indicates whether signature verification is enabled for the Event Webhook. When enabled, SendGrid signs webhook payloads with a private key.",
+				Computed:            true,
+			},
+			"public_key": schema.StringAttribute{
+				MarkdownDescription: "The public key used to verify webhook signatures. This field is populated when signature verification is enabled.",
+				Computed:            true,
+			},
 		},
 	}
 }
@@ -171,7 +181,7 @@ func (d *eventWebhookDataSource) Read(ctx context.Context, req datasource.ReadRe
 		return
 	}
 
-	u := eventWebhookResourceModel{
+	u := eventWebhookDataSourceModel{
 		ID:               types.StringValue(o.ID),
 		Enabled:          types.BoolValue(o.Enabled),
 		URL:              types.StringValue(o.URL),
@@ -189,6 +199,8 @@ func (d *eventWebhookDataSource) Read(ctx context.Context, req datasource.ReadRe
 		FriendlyName:     types.StringValue(o.FriendlyName),
 		OAuthClientID:    types.StringValue(o.OAuthClientID),
 		OAuthTokenURL:    types.StringValue(o.OAuthTokenURL),
+		Signed:           types.BoolValue(o.PublicKey != ""),
+		PublicKey:        types.StringValue(o.PublicKey),
 	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &u)...)


### PR DESCRIPTION
fix: https://github.com/kenzo0107/terraform-provider-sendgrid/issues/127

- Upgrade github.com/kenzo0107/sendgrid from v1.6.0 to v1.7.0
- Add webhook signature verification support with 'signed' field
- Add public_key field for webhook signature validation
- Optimize API calls to fetch webhook data only when necessary
- Update examples to demonstrate signing feature
- Generate updated documentation

🤖 Generated with [Claude Code](https://claude.ai/code)