### PR TITLE
Support WriteOnly for subuser password attribute

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,13 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@cb9bde2e2525e640591a934b1fd28eef1dcaf5e5 # v6.2.0
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           args: release --clean
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - run: go mod download
       - run: go build -v .
       - name: Run linters
-        uses: golangci/golangci-lint-action@7409966d8b436f844cc71daeb79a8b62c9827c0c # v6.3.0
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           version: latest
 
@@ -39,7 +39,7 @@ jobs:
       matrix:
         # list whatever Terraform versions here you would like to support
         terraform:
-          - '1.10.*'
+          - '1.11.4'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
@@ -51,6 +51,7 @@ jobs:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false
       - run: go generate ./...
+      - run: git diff
       - name: git diff
         run: |
           git diff --compact-summary --exit-code || \
@@ -68,7 +69,7 @@ jobs:
       matrix:
         # list whatever Terraform versions here you would like to support
         terraform:
-          - '1.10.*'
+          - '1.11.4'
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
-golang 1.23.6
+golang 1.24.0
+terraform 1.11.4

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 ## Requirements
 
-- [Terraform](https://www.terraform.io/downloads.html) >= 1.0
-- [Go](https://golang.org/doc/install) >= 1.23.6
+- [Terraform](https://www.terraform.io/downloads.html) >= 1.11
+- [Go](https://golang.org/doc/install) >= 1.24.0
 
 ## Building The Provider
 

--- a/docs/resources/subuser.md
+++ b/docs/resources/subuser.md
@@ -20,10 +20,11 @@ For more detailed information, please see the [SendGrid documentation](https://d
 
 ```terraform
 resource "sendgrid_subuser" "example" {
-  username = "dummy"
-  email    = "dummy@example.com"
-  password = "dummy"
-  ips      = ["1.1.1.2"]
+  username            = "dummy"
+  email               = "dummy@example.com"
+  password_wo         = "dummydummy1!"
+  password_wo_version = 1
+  ips                 = ["1.1.1.2"]
 }
 ```
 
@@ -34,8 +35,15 @@ resource "sendgrid_subuser" "example" {
 
 - `email` (String) The email of the subuser.
 - `ips` (Set of String) The IP addresses that should be assigned to this subuser.
-- `password` (String, Sensitive) The password of the subuser. NOTE: The password will only be saved in the tfstate during the execution of the creation.
 - `username` (String) The username of the subuser.
+
+### Optional
+
+> **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
+
+- `password` (String, Sensitive) The password of the subuser. NOTE: The password will only be saved in the tfstate during the execution of the creation.
+- `password_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The write-only password of the subuser. NOTE: password_wo is write-only and cannot be saved in the tfstate.
+- `password_wo_version` (Number) The version of the write-only password of the subuser. Change this value to rotate the write-only password. `Important` The SendGrid API currently does not support updating subuser passwords. To change a password, the subuser must be recreated.
 
 ### Read-Only
 

--- a/examples/resources/sendgrid_subuser/resource.tf
+++ b/examples/resources/sendgrid_subuser/resource.tf
@@ -1,6 +1,7 @@
 resource "sendgrid_subuser" "example" {
-  username = "dummy"
-  email    = "dummy@example.com"
-  password = "dummy"
-  ips      = ["1.1.1.2"]
+  username            = "dummy"
+  email               = "dummy@example.com"
+  password_wo         = "dummydummy1!"
+  password_wo_version = 1
+  ips                 = ["1.1.1.2"]
 }


### PR DESCRIPTION
 Subuser passwords are highly sensitive.
By supporting the WriteOnly attribute, passwords are no longer stored in plain text within the tfstate file. This change allows passwords to be managed securely in appropriate secret storage, improving overall security.
Terraform version 1.11 or later is required, as write-only attributes are supported starting from this version.