### PR TITLE
Update SendGrid client library to v1.9.0 and optimize subuser retrieval

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.29.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.3
-	github.com/kenzo0107/sendgrid v1.8.1
+	github.com/kenzo0107/sendgrid v1.9.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -136,12 +136,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
-github.com/kenzo0107/sendgrid v1.7.0 h1:ZaPwWcjR3EE974qsrkCgFFYmQq2hE9Y4jRfp4qR7JVc=
-github.com/kenzo0107/sendgrid v1.7.0/go.mod h1:o93EmGpbWbhaxLoiGB+x6g3tLof7TwbUlzjHNLvpDP8=
-github.com/kenzo0107/sendgrid v1.8.0 h1:YwqRSMXG/rdP4XwY+6QPKjsZnWoQ6xmohytDVMps9SU=
-github.com/kenzo0107/sendgrid v1.8.0/go.mod h1:N2OqlVLeSmHYOg7ULP6nURt0O5edKHIc16/eVRK4uoE=
-github.com/kenzo0107/sendgrid v1.8.1 h1:AIIqDttUCHalFJ6rFcDN3kyLOAipJ+brrPAbuJrRT6A=
-github.com/kenzo0107/sendgrid v1.8.1/go.mod h1:N2OqlVLeSmHYOg7ULP6nURt0O5edKHIc16/eVRK4uoE=
+github.com/kenzo0107/sendgrid v1.9.0 h1:J+FY3YpQBUnStFG0UjqwCqhzjqNfP74kKNSIDBBC3z0=
+github.com/kenzo0107/sendgrid v1.9.0/go.mod h1:N2OqlVLeSmHYOg7ULP6nURt0O5edKHIc16/eVRK4uoE=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -203,8 +199,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=
 github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider/subuser_data_source.go
+++ b/internal/provider/subuser_data_source.go
@@ -89,10 +89,7 @@ func (d *subuserDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 	username := s.Username.ValueString()
 
-	subusers, err := d.client.GetSubusers(ctx, &sendgrid.InputGetSubusers{
-		Username: username,
-		Limit:    1,
-	})
+	subuser, err := d.client.GetSubuser(ctx, username)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Reading subuser",
@@ -100,16 +97,6 @@ func (d *subuserDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		)
 		return
 	}
-
-	if len(subusers) == 0 {
-		resp.Diagnostics.AddError(
-			"Reading subuser",
-			fmt.Sprintf("Unable to read subuser (username: %s)", username),
-		)
-		return
-	}
-
-	subuser := subusers[0]
 
 	s = subuserDataSourceModel{
 		ID:       types.Int64Value(subuser.ID),

--- a/internal/provider/subuser_resource.go
+++ b/internal/provider/subuser_resource.go
@@ -211,10 +211,7 @@ func (r *subuserResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	username := state.Username.ValueString()
 
-	subusers, err := r.client.GetSubusers(ctx, &sendgrid.InputGetSubusers{
-		Username: username,
-		Limit:    1,
-	})
+	subuser, err := r.client.GetSubuser(ctx, username)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Reading subuser",
@@ -223,19 +220,10 @@ func (r *subuserResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	if len(subusers) == 0 {
-		resp.Diagnostics.AddError(
-			"Reading subuser",
-			fmt.Sprintf("Unable to read subuser (username: %s)", username),
-		)
-		return
-	}
-
 	if state.Ips.IsNull() {
 		state.Ips = types.SetNull(types.StringType)
 	}
 
-	subuser := subusers[0]
 	state.ID = types.Int64Value(subuser.ID)
 	state.Email = types.StringValue(subuser.Email)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -299,10 +287,7 @@ func (r *subuserResource) ImportState(ctx context.Context, req resource.ImportSt
 
 	resource.ImportStatePassthroughID(ctx, path.Root("username"), req, resp)
 
-	subusers, err := r.client.GetSubusers(ctx, &sendgrid.InputGetSubusers{
-		Username: username,
-		Limit:    1,
-	})
+	subuser, err := r.client.GetSubuser(ctx, username)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Importing subuser",
@@ -310,16 +295,6 @@ func (r *subuserResource) ImportState(ctx context.Context, req resource.ImportSt
 		)
 		return
 	}
-
-	if len(subusers) == 0 {
-		resp.Diagnostics.AddError(
-			"Importing subuser",
-			fmt.Sprintf("Unable to read subuser (username: %s)", username),
-		)
-		return
-	}
-
-	subuser := subusers[0]
 
 	data = subuserResourceModel{
 		ID:       types.Int64Value(subuser.ID),


### PR DESCRIPTION
- Bump github.com/kenzo0107/sendgrid from v1.8.1 to v1.9.0
- Use GetSubuser API for more efficient individual subuser retrieval
- Replace bulk retrieval via GetSubusers with targeted calls to reduce unnecessary processing