### PR TITLE
Add region attribute to subuser resource

### DIFF
--- a/docs/resources/subuser.md
+++ b/docs/resources/subuser.md
@@ -44,6 +44,7 @@ resource "sendgrid_subuser" "example" {
 - `password` (String, Sensitive) The password of the subuser. NOTE: The password will only be saved in the tfstate during the execution of the creation.
 - `password_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The write-only password of the subuser. NOTE: password_wo is write-only and cannot be saved in the tfstate.
 - `password_wo_version` (Number) The version of the write-only password of the subuser. Change this value to rotate the write-only password. `Important` The SendGrid API currently does not support updating subuser passwords. To change a password, the subuser must be recreated.
+- `region` (String) The region where the subuser is created. This attribute is for informational purposes only.
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.29.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/kenzo0107/sendgrid v1.9.0
+	github.com/kenzo0107/sendgrid v1.9.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -138,6 +138,8 @@ github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5Xum
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/kenzo0107/sendgrid v1.9.0 h1:J+FY3YpQBUnStFG0UjqwCqhzjqNfP74kKNSIDBBC3z0=
 github.com/kenzo0107/sendgrid v1.9.0/go.mod h1:N2OqlVLeSmHYOg7ULP6nURt0O5edKHIc16/eVRK4uoE=
+github.com/kenzo0107/sendgrid v1.9.1 h1:LNe7bWw88lXYIOM0dVDAFNCte7Z042JIdGd4ykhLIAk=
+github.com/kenzo0107/sendgrid v1.9.1/go.mod h1:N2OqlVLeSmHYOg7ULP6nURt0O5edKHIc16/eVRK4uoE=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
issue: https://github.com/kenzo0107/terraform-provider-sendgrid/issues/158

- Update sendgrid client library to v1.9.1
- Add region attribute with default value "global" and validation
- Switch from GetSubuser to GetSubusers API to retrieve region information
- Update resource documentation to include region attribute description