### PR TITLE
Added region attribute to sender_authentication resource

### DIFF
--- a/docs/resources/sender_authentication.md
+++ b/docs/resources/sender_authentication.md
@@ -39,6 +39,8 @@ output "ips" {
 
 - `custom_dkim_selector` (String) Add a custom DKIM selector. Accepts three letters or numbers.
 - `default` (Boolean) Whether to use this authenticated domain as the fallback if no authenticated domains match the sender's domain.
+- `region` (String) The region associated with this authenticated domain. This is either "global" or "eu", depending on the location of the data center that authenticated the domain.
+Note: The region attribute can only be specified during resource creation. When importing an existing Sender Authentication, the region is not returned by the SendGrid API and will default to global.
 - `subdomain` (String) The subdomain to use for this authenticated domain.
 
 ### Read-Only

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.30.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/kenzo0107/sendgrid v1.12.0
+	github.com/kenzo0107/sendgrid v1.12.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
-github.com/kenzo0107/sendgrid v1.12.0 h1:wuK64zieJE3swpQY8H5xWfeuSnhZIFYSBkMvYQsqZlA=
-github.com/kenzo0107/sendgrid v1.12.0/go.mod h1:GjfYUOWxQ0+RqJQyb+uO5CpdanIj6hamYzmE/1dNDWw=
+github.com/kenzo0107/sendgrid v1.12.1 h1:TrbQy9EIM3lNggKAWbJqjtwsZw/VLef69Ga1Z2DDPXA=
+github.com/kenzo0107/sendgrid v1.12.1/go.mod h1:GjfYUOWxQ0+RqJQyb+uO5CpdanIj6hamYzmE/1dNDWw=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/internal/provider/sender_authentication_resource.go
+++ b/internal/provider/sender_authentication_resource.go
@@ -14,9 +14,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/kenzo0107/sendgrid"
 	"github.com/kenzo0107/terraform-provider-sendgrid/flex"
 )
@@ -45,6 +48,7 @@ type senderAuthenticationResourceModel struct {
 	CustomDkimSelector types.String `tfsdk:"custom_dkim_selector"`
 	DNS                types.Set    `tfsdk:"dns"`
 	Valid              types.Bool   `tfsdk:"valid"`
+	Region             types.String `tfsdk:"region"`
 }
 
 func (r *senderAuthenticationResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -137,6 +141,22 @@ For more detailed information, please see the [SendGrid documentation](https://d
 					},
 				},
 			},
+			"region": schema.StringAttribute{
+				MarkdownDescription: `The region associated with this authenticated domain. This is either "global" or "eu", depending on the location of the data center that authenticated the domain.
+Note: The region attribute can only be specified during resource creation. When importing an existing Sender Authentication, the region is not returned by the SendGrid API and will default to global.`,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringOneOf(
+						"global",
+						"eu",
+					),
+				},
+				Default: stringdefault.StaticString("global"),
+			},
 		},
 	}
 }
@@ -170,6 +190,7 @@ func (r *senderAuthenticationResource) Create(ctx context.Context, req resource.
 	domain := data.Domain.ValueString()
 	input := &sendgrid.InputAuthenticateDomain{
 		Domain: domain,
+		Region: data.Region.ValueString(),
 	}
 
 	subdomain := data.Subdomain.ValueString()
@@ -192,6 +213,10 @@ func (r *senderAuthenticationResource) Create(ctx context.Context, req resource.
 	if customDkimSelector != "" {
 		input.CustomDkimSelector = customDkimSelector
 	}
+
+	tflog.Info(ctx, "Create (^-^)", map[string]interface{}{
+		"input": input,
+	})
 
 	res, err := retryOnRateLimit(ctx, func() (interface{}, error) {
 		return r.client.AuthenticateDomain(context.TODO(), input)
@@ -384,6 +409,9 @@ func (r *senderAuthenticationResource) ImportState(ctx context.Context, req reso
 	data.Legacy = types.BoolValue(o.Legacy)
 	data.Valid = types.BoolValue(o.Valid)
 	data.DNS = convertDNSToSetType(o.DNS)
+
+	// region is not returned in the GetAuthenticatedDomain response, so we set it to the default value during import
+	data.Region = types.StringValue("global")
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 	if resp.Diagnostics.HasError() {


### PR DESCRIPTION
fix: https://github.com/kenzo0107/terraform-provider-sendgrid/issues/178

- Accepts "global" or "eu" values (default: global)
- Specifiable only when creating the resource (must be recreated if changed)
- Sets default value during imports as SendGrid API does not return region information
- Updated sendgrid client to version v1.12.1