### PR TITLE
Updated to sendgrid v1.12.2 and added the automatic_security attribute to the sender_authentication resource

### DIFF
--- a/docs/resources/sender_authentication.md
+++ b/docs/resources/sender_authentication.md
@@ -37,6 +37,7 @@ output "ips" {
 
 ### Optional
 
+- `automatic_security` (Boolean) Whether to allow SendGrid to manage your SPF records, DKIM keys, and DKIM key rotation. (default: true)
 - `custom_dkim_selector` (String) Add a custom DKIM selector. Accepts three letters or numbers.
 - `default` (Boolean) Whether to use this authenticated domain as the fallback if no authenticated domains match the sender's domain.
 - `region` (String) The region associated with this authenticated domain. This is either "global" or "eu", depending on the location of the data center that authenticated the domain.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.30.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/kenzo0107/sendgrid v1.12.1
+	github.com/kenzo0107/sendgrid v1.12.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
-github.com/kenzo0107/sendgrid v1.12.1 h1:TrbQy9EIM3lNggKAWbJqjtwsZw/VLef69Ga1Z2DDPXA=
-github.com/kenzo0107/sendgrid v1.12.1/go.mod h1:GjfYUOWxQ0+RqJQyb+uO5CpdanIj6hamYzmE/1dNDWw=
+github.com/kenzo0107/sendgrid v1.12.2 h1:8aw2IgKA/4lvz5Oa6kxtY23SCXPEbyY63tDId5FwAA0=
+github.com/kenzo0107/sendgrid v1.12.2/go.mod h1:GjfYUOWxQ0+RqJQyb+uO5CpdanIj6hamYzmE/1dNDWw=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/internal/provider/sender_authentication_resource.go
+++ b/internal/provider/sender_authentication_resource.go
@@ -13,13 +13,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/kenzo0107/sendgrid"
 	"github.com/kenzo0107/terraform-provider-sendgrid/flex"
 )
@@ -49,6 +49,7 @@ type senderAuthenticationResourceModel struct {
 	DNS                types.Set    `tfsdk:"dns"`
 	Valid              types.Bool   `tfsdk:"valid"`
 	Region             types.String `tfsdk:"region"`
+	AutomaticSecurity  types.Bool   `tfsdk:"automatic_security"`
 }
 
 func (r *senderAuthenticationResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -157,6 +158,15 @@ Note: The region attribute can only be specified during resource creation. When 
 				},
 				Default: stringdefault.StaticString("global"),
 			},
+			"automatic_security": schema.BoolAttribute{
+				MarkdownDescription: "Whether to allow SendGrid to manage your SPF records, DKIM keys, and DKIM key rotation. (default: true)",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(true),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
+			},
 		},
 	}
 }
@@ -189,8 +199,9 @@ func (r *senderAuthenticationResource) Create(ctx context.Context, req resource.
 
 	domain := data.Domain.ValueString()
 	input := &sendgrid.InputAuthenticateDomain{
-		Domain: domain,
-		Region: data.Region.ValueString(),
+		Domain:            domain,
+		Region:            data.Region.ValueString(),
+		AutomaticSecurity: data.AutomaticSecurity.ValueBool(),
 	}
 
 	subdomain := data.Subdomain.ValueString()
@@ -213,10 +224,6 @@ func (r *senderAuthenticationResource) Create(ctx context.Context, req resource.
 	if customDkimSelector != "" {
 		input.CustomDkimSelector = customDkimSelector
 	}
-
-	tflog.Info(ctx, "Create (^-^)", map[string]interface{}{
-		"input": input,
-	})
 
 	res, err := retryOnRateLimit(ctx, func() (interface{}, error) {
 		return r.client.AuthenticateDomain(context.TODO(), input)
@@ -243,19 +250,22 @@ func (r *senderAuthenticationResource) Create(ctx context.Context, req resource.
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	data.IPs = ipsSet
 
 	id := strconv.FormatInt(o.ID, 10)
-	data.ID = types.StringValue(id)
-	data.UserID = types.Int64Value(o.UserID)
-	data.Domain = types.StringValue(o.Domain)
-	data.Subdomain = types.StringValue(o.Subdomain)
-	data.Username = types.StringValue(o.Username)
-	data.Default = types.BoolValue(o.Default)
-	data.Legacy = types.BoolValue(o.Legacy)
-	data.Valid = types.BoolValue(o.Valid)
-	data.DNS = convertDNSToSetType(o.DNS)
-
+	data = senderAuthenticationResourceModel{
+		ID:                types.StringValue(id),
+		UserID:            types.Int64Value(o.UserID),
+		Domain:            types.StringValue(o.Domain),
+		Subdomain:         types.StringValue(o.Subdomain),
+		Username:          types.StringValue(o.Username),
+		Default:           types.BoolValue(o.Default),
+		Legacy:            types.BoolValue(o.Legacy),
+		Valid:             types.BoolValue(o.Valid),
+		DNS:               convertDNSToSetType(o.DNS),
+		AutomaticSecurity: types.BoolValue(o.AutomaticSecurity),
+		IPs:               ipsSet,
+		Region:            data.Region,
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -285,16 +295,21 @@ func (r *senderAuthenticationResource) Read(ctx context.Context, req resource.Re
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	data.IPs = ipsSet
 
-	data.UserID = types.Int64Value(o.UserID)
-	data.Domain = types.StringValue(o.Domain)
-	data.Subdomain = types.StringValue(o.Subdomain)
-	data.Username = types.StringValue(o.Username)
-	data.Default = types.BoolValue(o.Default)
-	data.Legacy = types.BoolValue(o.Legacy)
-	data.Valid = types.BoolValue(o.Valid)
-	data.DNS = convertDNSToSetType(o.DNS)
+	data = senderAuthenticationResourceModel{
+		ID:                types.StringValue(id),
+		IPs:               ipsSet,
+		UserID:            types.Int64Value(o.UserID),
+		Domain:            types.StringValue(o.Domain),
+		Subdomain:         types.StringValue(o.Subdomain),
+		Username:          types.StringValue(o.Username),
+		Default:           types.BoolValue(o.Default),
+		Legacy:            types.BoolValue(o.Legacy),
+		Valid:             types.BoolValue(o.Valid),
+		DNS:               convertDNSToSetType(o.DNS),
+		AutomaticSecurity: types.BoolValue(o.AutomaticSecurity),
+		Region:            data.Region,
+	}
 
 	// The SendGrid API does not return the region in the GetAuthenticatedDomain response, so we set it to the default value during read
 	if data.Region.ValueString() == "" {
@@ -335,16 +350,25 @@ func (r *senderAuthenticationResource) Update(ctx context.Context, req resource.
 		return
 	}
 
-	data.ID = types.StringValue(strconv.FormatInt(o.ID, 10))
-	data.UserID = types.Int64Value(o.UserID)
-	data.Subdomain = types.StringValue(o.Subdomain)
-	data.Domain = types.StringValue(o.Domain)
-	data.Username = types.StringValue(o.Username)
-	data.IPs = ipsSet
-	data.Default = types.BoolValue(o.Default)
-	data.Legacy = types.BoolValue(o.Legacy)
-	data.Valid = types.BoolValue(o.Valid)
-	data.DNS = convertDNSToSetType(o.DNS)
+	data = senderAuthenticationResourceModel{
+		ID:                types.StringValue(strconv.FormatInt(o.ID, 10)),
+		UserID:            types.Int64Value(o.UserID),
+		Domain:            types.StringValue(o.Domain),
+		Subdomain:         types.StringValue(o.Subdomain),
+		Username:          types.StringValue(o.Username),
+		Default:           types.BoolValue(o.Default),
+		Legacy:            types.BoolValue(o.Legacy),
+		Valid:             types.BoolValue(o.Valid),
+		DNS:               convertDNSToSetType(o.DNS),
+		AutomaticSecurity: types.BoolValue(o.AutomaticSecurity),
+		IPs:               ipsSet,
+		Region:            data.Region,
+	}
+
+	// The SendGrid API does not return the region in the GetAuthenticatedDomain response, so we set it to the default value during read
+	if data.Region.ValueString() == "" {
+		data.Region = types.StringValue("global")
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -353,13 +377,13 @@ func (r *senderAuthenticationResource) Update(ctx context.Context, req resource.
 }
 
 func (r *senderAuthenticationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var data senderAuthenticationResourceModel
-	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	var state senderAuthenticationResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	domainId := data.ID.ValueString()
+	domainId := state.ID.ValueString()
 	id, _ := strconv.ParseInt(domainId, 10, 64)
 	_, err := retryOnRateLimit(ctx, func() (interface{}, error) {
 		return nil, r.client.DeleteAuthenticatedDomain(ctx, id)
@@ -403,18 +427,19 @@ func (r *senderAuthenticationResource) ImportState(ctx context.Context, req reso
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
-	data.ID = types.StringValue(strconv.FormatInt(o.ID, 10))
-	data.UserID = types.Int64Value(o.UserID)
-	data.Domain = types.StringValue(o.Domain)
-	data.Subdomain = types.StringValue(o.Subdomain)
-	data.Username = types.StringValue(o.Username)
-	data.IPs = ipsSet
-	data.Default = types.BoolValue(o.Default)
-	data.Legacy = types.BoolValue(o.Legacy)
-	data.Valid = types.BoolValue(o.Valid)
-	data.DNS = convertDNSToSetType(o.DNS)
-
+	data = senderAuthenticationResourceModel{
+		ID:                types.StringValue(strconv.FormatInt(o.ID, 10)),
+		UserID:            types.Int64Value(o.UserID),
+		Domain:            types.StringValue(o.Domain),
+		Subdomain:         types.StringValue(o.Subdomain),
+		Username:          types.StringValue(o.Username),
+		Default:           types.BoolValue(o.Default),
+		Legacy:            types.BoolValue(o.Legacy),
+		Valid:             types.BoolValue(o.Valid),
+		DNS:               convertDNSToSetType(o.DNS),
+		AutomaticSecurity: types.BoolValue(o.AutomaticSecurity),
+		IPs:               ipsSet,
+	}
 	// region is not returned in the GetAuthenticatedDomain response, so we set it to the default value during import
 	data.Region = types.StringValue("global")
 

--- a/internal/provider/sender_authentication_resource_test.go
+++ b/internal/provider/sender_authentication_resource_test.go
@@ -29,6 +29,7 @@ func TestAccSenderAuthenticationResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "valid", "false"),
 					resource.TestCheckResourceAttr(resourceName, "default", "false"),
 					resource.TestCheckResourceAttr(resourceName, "legacy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "automatic_security", "true"),
 				),
 			},
 			// ImportState testing
@@ -46,6 +47,7 @@ func TestAccSenderAuthenticationResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "valid", "false"),
 					resource.TestCheckResourceAttr(resourceName, "default", "false"),
 					resource.TestCheckResourceAttr(resourceName, "legacy", "false"),
+					resource.TestCheckResourceAttr(resourceName, "automatic_security", "true"),
 				),
 			},
 		},


### PR DESCRIPTION
- Upgraded the sendgrid client library from v1.12.1 to v1.12.2
- Added the automatic_security attribute (default: true)
- Modified the Create method to set the AutomaticSecurity field in InputAuthenticateDomain
- Fixed to preserve the AutomaticSecurity value during Read, Update, and ImportState operations
- Removed unnecessary tflog debug output
- Added automatic_security validation to tests