### PR TITLE
Updated the sendgrid client library to version v1.12.3 and added support for MailServer, SubdomainSpf, and Dkim records in the DNS record conversion process.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
-	github.com/kenzo0107/sendgrid v1.12.2
+	github.com/kenzo0107/sendgrid v1.12.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
-github.com/kenzo0107/sendgrid v1.12.2 h1:8aw2IgKA/4lvz5Oa6kxtY23SCXPEbyY63tDId5FwAA0=
-github.com/kenzo0107/sendgrid v1.12.2/go.mod h1:GjfYUOWxQ0+RqJQyb+uO5CpdanIj6hamYzmE/1dNDWw=
+github.com/kenzo0107/sendgrid v1.12.3 h1:hyLRy1KfYJDXiMn10kTn1qwcFb5Icn+iGdegokT1ZPE=
+github.com/kenzo0107/sendgrid v1.12.3/go.mod h1:GjfYUOWxQ0+RqJQyb+uO5CpdanIj6hamYzmE/1dNDWw=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/internal/provider/sender_authentication_resource.go
+++ b/internal/provider/sender_authentication_resource.go
@@ -500,6 +500,55 @@ func convertDNSToSetType(dns sendgrid.DNS) (recordsSet basetypes.SetValue) {
 			},
 		))
 	}
+	if dns.MailServer.Type != "" {
+		records = append(records, types.ObjectValueMust(
+			map[string]attr.Type{
+				"valid": types.BoolType,
+				"type":  types.StringType,
+				"host":  types.StringType,
+				"data":  types.StringType,
+			},
+			map[string]attr.Value{
+				"valid": types.BoolValue(dns.MailServer.Valid),
+				"type":  types.StringValue(dns.MailServer.Type),
+				"host":  types.StringValue(dns.MailServer.Host),
+				"data":  types.StringValue(dns.MailServer.Data),
+			},
+		))
+	}
+	if dns.SubdomainSpf.Type != "" {
+		records = append(records, types.ObjectValueMust(
+			map[string]attr.Type{
+				"valid": types.BoolType,
+				"type":  types.StringType,
+				"host":  types.StringType,
+				"data":  types.StringType,
+			},
+			map[string]attr.Value{
+				"valid": types.BoolValue(dns.SubdomainSpf.Valid),
+				"type":  types.StringValue(dns.SubdomainSpf.Type),
+				"host":  types.StringValue(dns.SubdomainSpf.Host),
+				"data":  types.StringValue(dns.SubdomainSpf.Data),
+			},
+		))
+	}
+	if dns.Dkim.Type != "" {
+		records = append(records, types.ObjectValueMust(
+			map[string]attr.Type{
+				"valid": types.BoolType,
+				"type":  types.StringType,
+				"host":  types.StringType,
+				"data":  types.StringType,
+			},
+			map[string]attr.Value{
+				"valid": types.BoolValue(dns.Dkim.Valid),
+				"type":  types.StringValue(dns.Dkim.Type),
+				"host":  types.StringValue(dns.Dkim.Host),
+				"data":  types.StringValue(dns.Dkim.Data),
+			},
+		))
+	}
+
 	var recordVariableElemType = types.ObjectType{
 		AttrTypes: map[string]attr.Type{
 			"valid": types.BoolType,


### PR DESCRIPTION
- go.mod, go.sum: Updated github.com/kenzo0107/sendgrid from version v1.12.2 to v1.12.3
- sender_authentication_resource.go: Added conversion logic for MailServer, SubdomainSpf, and Dkim records to the convertDNSToSetType function
- Removed the terraform-provider-sendgrid binary