### PR TITLE
Added SENDGRID_API_HOST environment variable and api_host provider configuration

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -31,6 +31,7 @@ type sendgridProvider struct {
 
 // sendgridProviderModel describes the provider data model.
 type sendgridProviderModel struct {
+	APIHost types.String `tfsdk:"api_host"`
 	APIKey  types.String `tfsdk:"api_key"`
 	Subuser types.String `tfsdk:"subuser"`
 }
@@ -43,6 +44,10 @@ func (p *sendgridProvider) Metadata(ctx context.Context, req provider.MetadataRe
 func (p *sendgridProvider) Schema(ctx context.Context, req provider.SchemaRequest, resp *provider.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"api_host": schema.StringAttribute{
+				MarkdownDescription: "FQDN for Sendgrid API. May also be provided via SENDGRID_API_HOST environment variable.",
+				Optional:            true,
+			},
 			"api_key": schema.StringAttribute{
 				MarkdownDescription: "API Key for Sendgrid API. May also be provided via SENDGRID_API_KEY environment variable.",
 				Optional:            true,
@@ -58,6 +63,7 @@ func (p *sendgridProvider) Schema(ctx context.Context, req provider.SchemaReques
 
 func (p *sendgridProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 	// Check environment variables
+	apiHost := os.Getenv("SENDGRID_API_HOST")
 	apiKey := os.Getenv("SENDGRID_API_KEY")
 	subuser := os.Getenv("SENDGRID_SUBUSER")
 
@@ -69,12 +75,21 @@ func (p *sendgridProvider) Configure(ctx context.Context, req provider.Configure
 	// Default values to environment variables, but override
 	// with Terraform configuration value if set.
 
+	if !config.APIHost.IsNull() {
+		apiHost = config.APIHost.ValueString()
+	}
+
 	if !config.APIKey.IsNull() {
 		apiKey = config.APIKey.ValueString()
 	}
 
 	if !config.Subuser.IsNull() {
 		subuser = config.Subuser.ValueString()
+	}
+
+	// Set default value for apiHost if not provided
+	if apiHost == "" {
+		apiHost = "api.sendgrid.com"
 	}
 
 	// If any of the expected configurations are missing, return
@@ -106,12 +121,16 @@ func (p *sendgridProvider) Configure(ctx context.Context, req provider.Configure
 		return
 	}
 
-	var client *sendgrid.Client
+	// Conditionally create slice of options for client creation
+	opts := []sendgrid.Option{}
 	if subuser != "" {
-		client = sendgrid.New(apiKey, sendgrid.OptionSubuser(subuser))
-	} else {
-		client = sendgrid.New(apiKey)
+		opts = append(opts, sendgrid.OptionSubuser(subuser))
 	}
+	if apiHost != "" {
+		opts = append(opts, sendgrid.OptionBaseURL(apiHost))
+	}
+
+	client := sendgrid.New(apiKey, opts...)
 
 	// Make the SendGrid api key available during DataSource and Resource
 	// type Configure methods.


### PR DESCRIPTION
- Added api_host attribute to provider schema
- Implemented support for the SENDGRID_API_HOST environment variable
- Set api.sendgrid.com as the default value
- Updated client initialization to use sendgrid.OptionBaseURL
