### PR TITLE
Updated the sendgrid client library to v1.13.0 and added support for the region parameter

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,4 +30,5 @@ provider "sendgrid" {
 ### Optional
 
 - `api_key` (String, Sensitive) API Key for Sendgrid API. May also be provided via SENDGRID_API_KEY environment variable.
+- `region` (String) Region for Sendgrid API. May also be provided via SENDGRID_REGION environment variable.
 - `subuser` (String) Subuser for Sendgrid API. May also be provided via SENDGRID_SUBUSER environment variable.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
-	github.com/kenzo0107/sendgrid v1.12.3
+	github.com/kenzo0107/sendgrid v1.13.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
-github.com/kenzo0107/sendgrid v1.12.3 h1:hyLRy1KfYJDXiMn10kTn1qwcFb5Icn+iGdegokT1ZPE=
-github.com/kenzo0107/sendgrid v1.12.3/go.mod h1:GjfYUOWxQ0+RqJQyb+uO5CpdanIj6hamYzmE/1dNDWw=
+github.com/kenzo0107/sendgrid v1.13.0 h1:rp78Tn5AL0QJEXHRMnvx9U5gZeVzM9CTWbdUWuWIoyc=
+github.com/kenzo0107/sendgrid v1.13.0/go.mod h1:GjfYUOWxQ0+RqJQyb+uO5CpdanIj6hamYzmE/1dNDWw=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -33,6 +33,7 @@ type sendgridProvider struct {
 type sendgridProviderModel struct {
 	APIKey  types.String `tfsdk:"api_key"`
 	Subuser types.String `tfsdk:"subuser"`
+	Region  types.String `tfsdk:"region"`
 }
 
 func (p *sendgridProvider) Metadata(ctx context.Context, req provider.MetadataRequest, resp *provider.MetadataResponse) {
@@ -52,6 +53,10 @@ func (p *sendgridProvider) Schema(ctx context.Context, req provider.SchemaReques
 				MarkdownDescription: "Subuser for Sendgrid API. May also be provided via SENDGRID_SUBUSER environment variable.",
 				Optional:            true,
 			},
+			"region": schema.StringAttribute{
+				MarkdownDescription: "Region for Sendgrid API. May also be provided via SENDGRID_REGION environment variable.",
+				Optional:            true,
+			},
 		},
 	}
 }
@@ -60,6 +65,12 @@ func (p *sendgridProvider) Configure(ctx context.Context, req provider.Configure
 	// Check environment variables
 	apiKey := os.Getenv("SENDGRID_API_KEY")
 	subuser := os.Getenv("SENDGRID_SUBUSER")
+	region := os.Getenv("SENDGRID_REGION")
+	tflog.Info(ctx, "(^-^)", map[string]interface{}{
+		"api_key": apiKey,
+		"subuser": subuser,
+		"region":  region,
+	})
 
 	// Retrieve provider data from configuration
 	var config sendgridProviderModel
@@ -75,6 +86,10 @@ func (p *sendgridProvider) Configure(ctx context.Context, req provider.Configure
 
 	if !config.Subuser.IsNull() {
 		subuser = config.Subuser.ValueString()
+	}
+
+	if !config.Region.IsNull() {
+		region = config.Region.ValueString()
 	}
 
 	// If any of the expected configurations are missing, return
@@ -106,12 +121,17 @@ func (p *sendgridProvider) Configure(ctx context.Context, req provider.Configure
 		return
 	}
 
-	var client *sendgrid.Client
+	opts := []sendgrid.Option{}
 	if subuser != "" {
-		client = sendgrid.New(apiKey, sendgrid.OptionSubuser(subuser))
-	} else {
-		client = sendgrid.New(apiKey)
+		opts = append(opts, sendgrid.OptionSubuser(subuser))
 	}
+
+	switch region {
+	case "eu":
+		opts = append(opts, sendgrid.OptionBaseURL(sendgrid.BaseURLEU))
+	}
+
+	client := sendgrid.New(apiKey, opts...)
 
 	// Make the SendGrid api key available during DataSource and Resource
 	// type Configure methods.


### PR DESCRIPTION
fix: https://github.com/kenzo0107/terraform-provider-sendgrid/issues/172

- Updated the sendgrid client library from version 1.12.3 to 1.13.0
- Added a region parameter to the provider configuration (also configurable via the SENDGRID_REGION environment variable)
- Configured to use EU endpoints when the region is set to "eu"
- Standardized all sendgrid.New() calls to use the Options pattern