### PR TITLE
Fixed to preserve custom_dkim_selector from state

### DIFF
--- a/docs/resources/sender_authentication.md
+++ b/docs/resources/sender_authentication.md
@@ -38,7 +38,7 @@ output "ips" {
 ### Optional
 
 - `automatic_security` (Boolean) Whether to allow SendGrid to manage your SPF records, DKIM keys, and DKIM key rotation. (default: true)
-- `custom_dkim_selector` (String) Add a custom DKIM selector. Accepts three letters or numbers.
+- `custom_dkim_selector` (String) Add a custom DKIM selector. Accepts three letters or numbers. The SendGrid API does not return the custom DKIM selector in the GetAuthenticatedDomain response, so we keep the value from the state.
 - `default` (Boolean) Whether to use this authenticated domain as the fallback if no authenticated domains match the sender's domain.
 - `region` (String) The region associated with this authenticated domain. This is either "global" or "eu", depending on the location of the data center that authenticated the domain.
 Note: The region attribute can only be specified during resource creation. When importing an existing Sender Authentication, the region is not returned by the SendGrid API and will default to global.

--- a/internal/provider/sender_authentication_resource.go
+++ b/internal/provider/sender_authentication_resource.go
@@ -109,7 +109,7 @@ For more detailed information, please see the [SendGrid documentation](https://d
 				Computed:            true,
 			},
 			"custom_dkim_selector": schema.StringAttribute{
-				MarkdownDescription: "Add a custom DKIM selector. Accepts three letters or numbers.",
+				MarkdownDescription: "Add a custom DKIM selector. Accepts three letters or numbers. The SendGrid API does not return the custom DKIM selector in the GetAuthenticatedDomain response, so we keep the value from the state.",
 				Optional:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -253,18 +253,19 @@ func (r *senderAuthenticationResource) Create(ctx context.Context, req resource.
 
 	id := strconv.FormatInt(o.ID, 10)
 	data = senderAuthenticationResourceModel{
-		ID:                types.StringValue(id),
-		UserID:            types.Int64Value(o.UserID),
-		Domain:            types.StringValue(o.Domain),
-		Subdomain:         types.StringValue(o.Subdomain),
-		Username:          types.StringValue(o.Username),
-		Default:           types.BoolValue(o.Default),
-		Legacy:            types.BoolValue(o.Legacy),
-		Valid:             types.BoolValue(o.Valid),
-		DNS:               convertDNSToSetType(o.DNS),
-		AutomaticSecurity: types.BoolValue(o.AutomaticSecurity),
-		IPs:               ipsSet,
-		Region:            data.Region,
+		ID:                 types.StringValue(id),
+		UserID:             types.Int64Value(o.UserID),
+		Domain:             types.StringValue(o.Domain),
+		Subdomain:          types.StringValue(o.Subdomain),
+		Username:           types.StringValue(o.Username),
+		Default:            types.BoolValue(o.Default),
+		Legacy:             types.BoolValue(o.Legacy),
+		CustomDkimSelector: data.CustomDkimSelector, // The SendGrid API does not return the custom DKIM selector in the GetAuthenticatedDomain response, so we keep the value from the state
+		Valid:              types.BoolValue(o.Valid),
+		DNS:                convertDNSToSetType(o.DNS),
+		AutomaticSecurity:  types.BoolValue(o.AutomaticSecurity),
+		IPs:                ipsSet,
+		Region:             data.Region,
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -297,18 +298,19 @@ func (r *senderAuthenticationResource) Read(ctx context.Context, req resource.Re
 	}
 
 	data = senderAuthenticationResourceModel{
-		ID:                types.StringValue(id),
-		IPs:               ipsSet,
-		UserID:            types.Int64Value(o.UserID),
-		Domain:            types.StringValue(o.Domain),
-		Subdomain:         types.StringValue(o.Subdomain),
-		Username:          types.StringValue(o.Username),
-		Default:           types.BoolValue(o.Default),
-		Legacy:            types.BoolValue(o.Legacy),
-		Valid:             types.BoolValue(o.Valid),
-		DNS:               convertDNSToSetType(o.DNS),
-		AutomaticSecurity: types.BoolValue(o.AutomaticSecurity),
-		Region:            data.Region,
+		ID:                 types.StringValue(id),
+		IPs:                ipsSet,
+		UserID:             types.Int64Value(o.UserID),
+		Domain:             types.StringValue(o.Domain),
+		Subdomain:          types.StringValue(o.Subdomain),
+		Username:           types.StringValue(o.Username),
+		Default:            types.BoolValue(o.Default),
+		Legacy:             types.BoolValue(o.Legacy),
+		CustomDkimSelector: data.CustomDkimSelector, // The SendGrid API does not return the custom DKIM selector in the GetAuthenticatedDomain response, so we keep the value from the state
+		Valid:              types.BoolValue(o.Valid),
+		DNS:                convertDNSToSetType(o.DNS),
+		AutomaticSecurity:  types.BoolValue(o.AutomaticSecurity),
+		Region:             data.Region,
 	}
 
 	// The SendGrid API does not return the region in the GetAuthenticatedDomain response, so we set it to the default value during read
@@ -351,18 +353,19 @@ func (r *senderAuthenticationResource) Update(ctx context.Context, req resource.
 	}
 
 	data = senderAuthenticationResourceModel{
-		ID:                types.StringValue(strconv.FormatInt(o.ID, 10)),
-		UserID:            types.Int64Value(o.UserID),
-		Domain:            types.StringValue(o.Domain),
-		Subdomain:         types.StringValue(o.Subdomain),
-		Username:          types.StringValue(o.Username),
-		Default:           types.BoolValue(o.Default),
-		Legacy:            types.BoolValue(o.Legacy),
-		Valid:             types.BoolValue(o.Valid),
-		DNS:               convertDNSToSetType(o.DNS),
-		AutomaticSecurity: types.BoolValue(o.AutomaticSecurity),
-		IPs:               ipsSet,
-		Region:            data.Region,
+		ID:                 types.StringValue(strconv.FormatInt(o.ID, 10)),
+		UserID:             types.Int64Value(o.UserID),
+		Domain:             types.StringValue(o.Domain),
+		Subdomain:          types.StringValue(o.Subdomain),
+		Username:           types.StringValue(o.Username),
+		Default:            types.BoolValue(o.Default),
+		Legacy:             types.BoolValue(o.Legacy),
+		CustomDkimSelector: data.CustomDkimSelector,
+		Valid:              types.BoolValue(o.Valid),
+		DNS:                convertDNSToSetType(o.DNS),
+		AutomaticSecurity:  types.BoolValue(o.AutomaticSecurity),
+		IPs:                ipsSet,
+		Region:             data.Region,
 	}
 
 	// The SendGrid API does not return the region in the GetAuthenticatedDomain response, so we set it to the default value during read
@@ -428,17 +431,18 @@ func (r *senderAuthenticationResource) ImportState(ctx context.Context, req reso
 		return
 	}
 	data = senderAuthenticationResourceModel{
-		ID:                types.StringValue(strconv.FormatInt(o.ID, 10)),
-		UserID:            types.Int64Value(o.UserID),
-		Domain:            types.StringValue(o.Domain),
-		Subdomain:         types.StringValue(o.Subdomain),
-		Username:          types.StringValue(o.Username),
-		Default:           types.BoolValue(o.Default),
-		Legacy:            types.BoolValue(o.Legacy),
-		Valid:             types.BoolValue(o.Valid),
-		DNS:               convertDNSToSetType(o.DNS),
-		AutomaticSecurity: types.BoolValue(o.AutomaticSecurity),
-		IPs:               ipsSet,
+		ID:                 types.StringValue(strconv.FormatInt(o.ID, 10)),
+		UserID:             types.Int64Value(o.UserID),
+		Domain:             types.StringValue(o.Domain),
+		Subdomain:          types.StringValue(o.Subdomain),
+		Username:           types.StringValue(o.Username),
+		Default:            types.BoolValue(o.Default),
+		Legacy:             types.BoolValue(o.Legacy),
+		CustomDkimSelector: types.StringNull(), // The SendGrid API does not return the custom DKIM selector in the GetAuthenticatedDomain response, so we set it to null during import
+		Valid:              types.BoolValue(o.Valid),
+		DNS:                convertDNSToSetType(o.DNS),
+		AutomaticSecurity:  types.BoolValue(o.AutomaticSecurity),
+		IPs:                ipsSet,
 	}
 	// region is not returned in the GetAuthenticatedDomain response, so we set it to the default value during import
 	data.Region = types.StringValue("global")


### PR DESCRIPTION
The GetAuthenticatedDomain response from the SendGrid API does not include a custom_dkim_selector field, requiring the value to be carried over from the state in the Read/Create/Update functions.

During refactoring of struct literal assignment in v2.8.1, the CustomDkimSelector was inadvertently omitted, resulting in the value being reset to null during Read operations and causing unnecessary replace operations.

Fix details:
- Read function: Maintains CustomDkimSelector value from the state
- Create function: Maintains CustomDkimSelector value from the plan
- Update function: Maintains CustomDkimSelector value from the state
- ImportState function: Explicitly sets CustomDkimSelector to null

Fixes #194 