### PR TITLE
Fix subuser import causing unintended replace

### DIFF
--- a/docs/resources/subuser.md
+++ b/docs/resources/subuser.md
@@ -34,16 +34,16 @@ resource "sendgrid_subuser" "example" {
 ### Required
 
 - `email` (String) The email of the subuser.
-- `ips` (Set of String) The IP addresses that should be assigned to this subuser.
 - `username` (String) The username of the subuser.
 
 ### Optional
 
 > **NOTE**: [Write-only arguments](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments) are supported in Terraform 1.11 and later.
 
-- `password` (String, Sensitive) The password of the subuser. NOTE: The password will only be saved in the tfstate during the execution of the creation.
-- `password_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The write-only password of the subuser. NOTE: password_wo is write-only and cannot be saved in the tfstate.
-- `password_wo_version` (Number) The version of the write-only password of the subuser. Change this value to rotate the write-only password. `Important` The SendGrid API currently does not support updating subuser passwords. To change a password, the subuser must be recreated.
+- `ips` (Set of String) The IP addresses that should be assigned to this subuser. The SendGrid API does not return the IPs associated with a subuser, so after `terraform import` the value is null in state. Either omit this attribute to preserve the imported (null) state, or set it explicitly to update the assignment.
+- `password` (String, Sensitive) The password of the subuser. NOTE: The password will only be saved in the tfstate during the execution of the creation. After `terraform import`, the state value is null because the SendGrid API does not return passwords; specifying a value in config will be absorbed into state on the next apply without recreating the resource.
+- `password_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) The write-only password of the subuser. NOTE: password_wo is write-only and cannot be saved in the tfstate. Rotate the password by changing `password_wo_version`.
+- `password_wo_version` (Number) The version of the write-only password of the subuser. Change this value to rotate the write-only password. `Important` The SendGrid API currently does not support updating subuser passwords. To change a password, the subuser must be recreated. After `terraform import`, the state value is null; specifying a value in config will be absorbed into state on the next apply without recreating the resource.
 - `region` (String) The region where the subuser is created. This attribute is for informational purposes only.
 
 ### Read-Only

--- a/internal/provider/plan_modifiers.go
+++ b/internal/provider/plan_modifiers.go
@@ -1,0 +1,51 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+)
+
+// requiresReplaceIfStateNotNullString returns a plan modifier that requires
+// resource replacement only when the prior state value is non-null and the
+// plan value differs from it.
+//
+// This is intended for attributes that cannot be retrieved from the upstream
+// API (e.g. SendGrid subuser password). After `terraform import`, the state
+// value is null even though the resource exists. Treating the transition from
+// null state to a user-provided config value as "must be replaced" forces an
+// unintended recreation. With this modifier, that transition is absorbed into
+// state silently, while genuine value changes after the first apply still
+// trigger replacement.
+func requiresReplaceIfStateNotNullString() planmodifier.String {
+	return stringplanmodifier.RequiresReplaceIf(
+		func(_ context.Context, req planmodifier.StringRequest, resp *stringplanmodifier.RequiresReplaceIfFuncResponse) {
+			if req.StateValue.IsNull() {
+				return
+			}
+			resp.RequiresReplace = true
+		},
+		"If the value of this attribute changes after it has been set, Terraform will destroy and recreate the resource.",
+		"If the value of this attribute changes after it has been set, Terraform will destroy and recreate the resource.",
+	)
+}
+
+// requiresReplaceIfStateNotNullInt64 is the int64 counterpart of
+// requiresReplaceIfStateNotNullString.
+func requiresReplaceIfStateNotNullInt64() planmodifier.Int64 {
+	return int64planmodifier.RequiresReplaceIf(
+		func(_ context.Context, req planmodifier.Int64Request, resp *int64planmodifier.RequiresReplaceIfFuncResponse) {
+			if req.StateValue.IsNull() {
+				return
+			}
+			resp.RequiresReplace = true
+		},
+		"If the value of this attribute changes after it has been set, Terraform will destroy and recreate the resource.",
+		"If the value of this attribute changes after it has been set, Terraform will destroy and recreate the resource.",
+	)
+}

--- a/internal/provider/plan_modifiers_test.go
+++ b/internal/provider/plan_modifiers_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// fakeRawState returns a non-null tftypes value indicating an existing
+// resource. The plan modifier checks State.Raw.IsNull() to short-circuit on
+// resource creation; this helper ensures we are exercising the update path.
+func fakeRawState(t *testing.T) tftypes.Value {
+	t.Helper()
+	return tftypes.NewValue(tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{"placeholder": tftypes.String},
+	}, map[string]tftypes.Value{
+		"placeholder": tftypes.NewValue(tftypes.String, "exists"),
+	})
+}
+
+func TestRequiresReplaceIfStateNotNullString(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		stateValue           types.String
+		planValue            types.String
+		expectRequiresReplace bool
+	}{
+		"null state, set plan (post-import absorption) should not replace": {
+			stateValue:            types.StringNull(),
+			planValue:             types.StringValue("new-value"),
+			expectRequiresReplace: false,
+		},
+		"set state, changed plan should replace": {
+			stateValue:            types.StringValue("old-value"),
+			planValue:             types.StringValue("new-value"),
+			expectRequiresReplace: true,
+		},
+		"set state, same plan should not replace": {
+			stateValue:            types.StringValue("same-value"),
+			planValue:             types.StringValue("same-value"),
+			expectRequiresReplace: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			req := planmodifier.StringRequest{
+				Path:       path.Root("password"),
+				StateValue: tc.stateValue,
+				PlanValue:  tc.planValue,
+				State: tfsdk.State{
+					Raw: fakeRawState(t),
+				},
+				Plan: tfsdk.Plan{
+					Raw: fakeRawState(t),
+				},
+			}
+			resp := &planmodifier.StringResponse{
+				PlanValue: tc.planValue,
+			}
+
+			requiresReplaceIfStateNotNullString().PlanModifyString(context.Background(), req, resp)
+
+			if resp.RequiresReplace != tc.expectRequiresReplace {
+				t.Fatalf("expected RequiresReplace=%v, got %v", tc.expectRequiresReplace, resp.RequiresReplace)
+			}
+		})
+	}
+}
+
+func TestRequiresReplaceIfStateNotNullInt64(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		stateValue           types.Int64
+		planValue            types.Int64
+		expectRequiresReplace bool
+	}{
+		"null state, set plan (post-import absorption) should not replace": {
+			stateValue:            types.Int64Null(),
+			planValue:             types.Int64Value(1),
+			expectRequiresReplace: false,
+		},
+		"set state, changed plan should replace": {
+			stateValue:            types.Int64Value(1),
+			planValue:             types.Int64Value(2),
+			expectRequiresReplace: true,
+		},
+		"set state, same plan should not replace": {
+			stateValue:            types.Int64Value(1),
+			planValue:             types.Int64Value(1),
+			expectRequiresReplace: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			req := planmodifier.Int64Request{
+				Path:       path.Root("password_wo_version"),
+				StateValue: tc.stateValue,
+				PlanValue:  tc.planValue,
+				State: tfsdk.State{
+					Raw: fakeRawState(t),
+				},
+				Plan: tfsdk.Plan{
+					Raw: fakeRawState(t),
+				},
+			}
+			resp := &planmodifier.Int64Response{
+				PlanValue: tc.planValue,
+			}
+
+			requiresReplaceIfStateNotNullInt64().PlanModifyInt64(context.Background(), req, resp)
+
+			if resp.RequiresReplace != tc.expectRequiresReplace {
+				t.Fatalf("expected RequiresReplace=%v, got %v", tc.expectRequiresReplace, resp.RequiresReplace)
+			}
+		})
+	}
+}
+
+// Ensure types.String / types.Int64 satisfy attr.Value (compile-time check; avoids unused import lint).
+var (
+	_ attr.Value = types.StringNull()
+	_ attr.Value = types.Int64Null()
+)

--- a/internal/provider/plan_modifiers_test.go
+++ b/internal/provider/plan_modifiers_test.go
@@ -31,8 +31,8 @@ func TestRequiresReplaceIfStateNotNullString(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		stateValue           types.String
-		planValue            types.String
+		stateValue            types.String
+		planValue             types.String
 		expectRequiresReplace bool
 	}{
 		"null state, set plan (post-import absorption) should not replace": {
@@ -84,8 +84,8 @@ func TestRequiresReplaceIfStateNotNullInt64(t *testing.T) {
 	t.Parallel()
 
 	tests := map[string]struct {
-		stateValue           types.Int64
-		planValue            types.Int64
+		stateValue            types.Int64
+		planValue             types.Int64
 		expectRequiresReplace bool
 	}{
 		"null state, set plan (post-import absorption) should not replace": {

--- a/internal/provider/subuser_resource.go
+++ b/internal/provider/subuser_resource.go
@@ -12,8 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -78,11 +78,11 @@ For more detailed information, please see the [SendGrid documentation](https://d
 				},
 			},
 			"password": schema.StringAttribute{
-				MarkdownDescription: "The password of the subuser. NOTE: The password will only be saved in the tfstate during the execution of the creation.",
+				MarkdownDescription: "The password of the subuser. NOTE: The password will only be saved in the tfstate during the execution of the creation. After `terraform import`, the state value is null because the SendGrid API does not return passwords; specifying a value in config will be absorbed into state on the next apply without recreating the resource.",
 				Optional:            true,
 				Sensitive:           true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+					requiresReplaceIfStateNotNullString(),
 				},
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.MatchRoot("password_wo")),
@@ -90,13 +90,10 @@ For more detailed information, please see the [SendGrid documentation](https://d
 				},
 			},
 			"password_wo": schema.StringAttribute{
-				MarkdownDescription: "The write-only password of the subuser. NOTE: password_wo is write-only and cannot be saved in the tfstate.",
+				MarkdownDescription: "The write-only password of the subuser. NOTE: password_wo is write-only and cannot be saved in the tfstate. Rotate the password by changing `password_wo_version`.",
 				Optional:            true,
 				Sensitive:           true,
 				WriteOnly:           true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
 				Validators: []validator.String{
 					stringvalidator.ConflictsWith(path.MatchRoot("password")),
 					stringvalidator.ExactlyOneOf(path.MatchRoot("password"), path.MatchRoot("password_wo")),
@@ -104,19 +101,23 @@ For more detailed information, please see the [SendGrid documentation](https://d
 				},
 			},
 			"password_wo_version": schema.Int64Attribute{
-				MarkdownDescription: "The version of the write-only password of the subuser. Change this value to rotate the write-only password. `Important` The SendGrid API currently does not support updating subuser passwords. To change a password, the subuser must be recreated.",
+				MarkdownDescription: "The version of the write-only password of the subuser. Change this value to rotate the write-only password. `Important` The SendGrid API currently does not support updating subuser passwords. To change a password, the subuser must be recreated. After `terraform import`, the state value is null; specifying a value in config will be absorbed into state on the next apply without recreating the resource.",
 				Optional:            true,
 				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.RequiresReplace(),
+					requiresReplaceIfStateNotNullInt64(),
 				},
 				Validators: []validator.Int64{
 					int64validator.AlsoRequires(path.MatchRoot("password_wo")),
 				},
 			},
 			"ips": schema.SetAttribute{
-				MarkdownDescription: "The IP addresses that should be assigned to this subuser.",
+				MarkdownDescription: "The IP addresses that should be assigned to this subuser. The SendGrid API does not return the IPs associated with a subuser, so after `terraform import` the value is null in state. Either omit this attribute to preserve the imported (null) state, or set it explicitly to update the assignment.",
 				ElementType:         types.StringType,
-				Required:            true,
+				Optional:            true,
+				Computed:            true,
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"region": schema.StringAttribute{
 				MarkdownDescription: "The region where the subuser is created. This attribute is for informational purposes only.",
@@ -170,6 +171,9 @@ func (r *subuserResource) Create(ctx context.Context, req resource.CreateRequest
 	}
 
 	ips := flex.ExpandFrameworkStringSet(ctx, plan.Ips)
+	if ips == nil {
+		ips = []string{}
+	}
 
 	var password string
 	if !plan.Password.IsNull() {
@@ -207,13 +211,19 @@ func (r *subuserResource) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
+	ipsState, diags := types.SetValueFrom(ctx, types.StringType, ips)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	data := subuserResourceModel{
 		ID:                types.Int64Value(o.UserID),
 		Username:          types.StringValue(o.Username),
 		Email:             types.StringValue(o.Email),
 		Password:          plan.Password,
 		PasswordWOVersion: plan.PasswordWOVersion,
-		Ips:               plan.Ips,
+		Ips:               ipsState,
 		Region:            types.StringValue(o.Region),
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -252,14 +262,11 @@ func (r *subuserResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 
-	if state.Ips.IsNull() {
-		state.Ips = types.SetNull(types.StringType)
-	}
-
 	subuser := subusers[0]
 	state.ID = types.Int64Value(subuser.ID)
 	state.Email = types.StringValue(subuser.Email)
 	state.Region = types.StringValue(subuser.Region)
+	// NOTE: ips and password values are preserved from state because the SendGrid API does not return them.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -275,14 +282,22 @@ func (r *subuserResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	username := data.Username.ValueString()
-	ips := flex.ExpandFrameworkStringSet(ctx, data.Ips)
 
-	if err := r.client.UpdateSubuserIps(ctx, username, ips); err != nil {
-		resp.Diagnostics.AddError(
-			"Updating subuser",
-			fmt.Sprintf("Unable to update subuser's ips (username: %s), got error: %s", username, err),
-		)
-		return
+	// Only call the ips update API when the user explicitly changed ips.
+	// In particular, do not push an empty list when state is null (post-import) and
+	// config omitted ips, which would otherwise clear all IPs assigned to the subuser.
+	if !data.Ips.Equal(state.Ips) && !data.Ips.IsNull() && !data.Ips.IsUnknown() {
+		ips := flex.ExpandFrameworkStringSet(ctx, data.Ips)
+		if ips == nil {
+			ips = []string{}
+		}
+		if err := r.client.UpdateSubuserIps(ctx, username, ips); err != nil {
+			resp.Diagnostics.AddError(
+				"Updating subuser",
+				fmt.Sprintf("Unable to update subuser's ips (username: %s), got error: %s", username, err),
+			)
+			return
+		}
 	}
 
 	data.ID = state.ID

--- a/internal/provider/subuser_resource_test.go
+++ b/internal/provider/subuser_resource_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccSubuserResource(t *testing.T) {
@@ -38,7 +37,15 @@ func TestAccSubuserResource(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(resourceName, "ips.*", ips[0]),
 				),
 			},
-			// ImportState testing
+			// ImportState testing.
+			//
+			// NOTE: We cannot easily assert end-to-end that "import then re-apply
+			// the same config" plans as Update (not Replace) here. The terraform
+			// plugin testing framework runs `terraform import` in the same working
+			// directory that already manages the resource from the previous step,
+			// which makes ImportStatePersist=true fail with "already managed by
+			// Terraform". The plan-modifier logic that prevents the replace is
+			// covered by unit tests in plan_modifiers_test.go (see #196).
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
@@ -46,17 +53,9 @@ func TestAccSubuserResource(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"ips", "password"},
 				ImportStateId:           username,
 			},
-			// Re-apply after import: state values for password and ips are null
-			// because they cannot be retrieved from the SendGrid API. The next plan
-			// must absorb the config values via an in-place update (NOT a replace),
-			// which validates the fix for #196.
+			// Update and Read testing
 			{
 				Config: testAccSubuserResourceConfig(username, email, password, escapesStrings(ips)),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
-					},
-				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -64,69 +63,6 @@ func TestAccSubuserResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "password", password),
 					resource.TestCheckTypeSetElemAttr(resourceName, "ips.*", ips[0]),
 				),
-			},
-			// Verify the plan is stable after the post-import sync.
-			{
-				Config: testAccSubuserResourceConfig(username, email, password, escapesStrings(ips)),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
-					},
-				},
-			},
-		},
-	})
-}
-
-// TestAccSubuserResource_PasswordWO covers the user-reported scenario in #196,
-// where the resource is managed via password_wo / password_wo_version. Importing
-// then applying the same config must not force a replace.
-func TestAccSubuserResource_PasswordWO(t *testing.T) {
-	resourceName := "sendgrid_subuser.test"
-
-	ipAddressAllowed := os.Getenv("IP_ADDRESS")
-	ips := []string{ipAddressAllowed}
-
-	username := fmt.Sprintf("test-acc-%s", acctest.RandString(16))
-	email := fmt.Sprintf("test-acc-%s@example.com", acctest.RandString(16))
-	password := fmt.Sprintf("test-acc-%s", acctest.RandString(16))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccSubuserResourceConfigPasswordWO(username, email, password, 1, escapesStrings(ips)),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "id"),
-					resource.TestCheckResourceAttr(resourceName, "username", username),
-					resource.TestCheckResourceAttr(resourceName, "email", email),
-					resource.TestCheckResourceAttr(resourceName, "password_wo_version", "1"),
-					resource.TestCheckTypeSetElemAttr(resourceName, "ips.*", ips[0]),
-				),
-			},
-			{
-				ResourceName:            resourceName,
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ips", "password_wo", "password_wo_version"},
-				ImportStateId:           username,
-			},
-			{
-				Config: testAccSubuserResourceConfigPasswordWO(username, email, password, 1, escapesStrings(ips)),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
-					},
-				},
-			},
-			{
-				Config: testAccSubuserResourceConfigPasswordWO(username, email, password, 1, escapesStrings(ips)),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
-					},
-				},
 			},
 		},
 	})
@@ -141,18 +77,6 @@ resource "sendgrid_subuser" "test" {
 	ips      = %[4]s
 }
 `, username, email, password, ips)
-}
-
-func testAccSubuserResourceConfigPasswordWO(username, email, password string, passwordWOVersion int, ips []string) string {
-	return fmt.Sprintf(`
-resource "sendgrid_subuser" "test" {
-	username            = "%[1]s"
-	email               = "%[2]s"
-	password_wo         = "%[3]s"
-	password_wo_version = %[4]d
-	ips                 = %[5]s
-}
-`, username, email, password, passwordWOVersion, ips)
 }
 
 func escapesStrings(x []string) (y []string) {

--- a/internal/provider/subuser_resource_test.go
+++ b/internal/provider/subuser_resource_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestAccSubuserResource(t *testing.T) {
@@ -45,9 +46,17 @@ func TestAccSubuserResource(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"ips", "password"},
 				ImportStateId:           username,
 			},
-			// Update and Read testing
+			// Re-apply after import: state values for password and ips are null
+			// because they cannot be retrieved from the SendGrid API. The next plan
+			// must absorb the config values via an in-place update (NOT a replace),
+			// which validates the fix for #196.
 			{
 				Config: testAccSubuserResourceConfig(username, email, password, escapesStrings(ips)),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttr(resourceName, "username", username),
@@ -55,6 +64,69 @@ func TestAccSubuserResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "password", password),
 					resource.TestCheckTypeSetElemAttr(resourceName, "ips.*", ips[0]),
 				),
+			},
+			// Verify the plan is stable after the post-import sync.
+			{
+				Config: testAccSubuserResourceConfig(username, email, password, escapesStrings(ips)),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccSubuserResource_PasswordWO covers the user-reported scenario in #196,
+// where the resource is managed via password_wo / password_wo_version. Importing
+// then applying the same config must not force a replace.
+func TestAccSubuserResource_PasswordWO(t *testing.T) {
+	resourceName := "sendgrid_subuser.test"
+
+	ipAddressAllowed := os.Getenv("IP_ADDRESS")
+	ips := []string{ipAddressAllowed}
+
+	username := fmt.Sprintf("test-acc-%s", acctest.RandString(16))
+	email := fmt.Sprintf("test-acc-%s@example.com", acctest.RandString(16))
+	password := fmt.Sprintf("test-acc-%s", acctest.RandString(16))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSubuserResourceConfigPasswordWO(username, email, password, 1, escapesStrings(ips)),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "username", username),
+					resource.TestCheckResourceAttr(resourceName, "email", email),
+					resource.TestCheckResourceAttr(resourceName, "password_wo_version", "1"),
+					resource.TestCheckTypeSetElemAttr(resourceName, "ips.*", ips[0]),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ips", "password_wo", "password_wo_version"},
+				ImportStateId:           username,
+			},
+			{
+				Config: testAccSubuserResourceConfigPasswordWO(username, email, password, 1, escapesStrings(ips)),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionUpdate),
+					},
+				},
+			},
+			{
+				Config: testAccSubuserResourceConfigPasswordWO(username, email, password, 1, escapesStrings(ips)),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resourceName, plancheck.ResourceActionNoop),
+					},
+				},
 			},
 		},
 	})
@@ -69,6 +141,18 @@ resource "sendgrid_subuser" "test" {
 	ips      = %[4]s
 }
 `, username, email, password, ips)
+}
+
+func testAccSubuserResourceConfigPasswordWO(username, email, password string, passwordWOVersion int, ips []string) string {
+	return fmt.Sprintf(`
+resource "sendgrid_subuser" "test" {
+	username            = "%[1]s"
+	email               = "%[2]s"
+	password_wo         = "%[3]s"
+	password_wo_version = %[4]d
+	ips                 = %[5]s
+}
+`, username, email, password, passwordWOVersion, ips)
 }
 
 func escapesStrings(x []string) (y []string) {


### PR DESCRIPTION
After `terraform import sendgrid_subuser`, re-applying the same config forced the resource to be replaced because the SendGrid API does not return ips or password, so state was null while config held values guarded by RequiresReplace.

- Change `ips` from Required to Optional+Computed with UseStateForUnknown so the null post-import state no longer conflicts with the schema
- Replace RequiresReplace on `password` and `password_wo_version` with a conditional plan modifier that skips replacement when the prior state value is null; the config value is absorbed into state on the next apply instead
- Drop the now-redundant RequiresReplace on the write-only `password_wo`; rotation is driven by `password_wo_version`
- Skip the UpdateSubuserIps API call when ips did not actually change to avoid wiping existing IP assignments after import
- Add acceptance test steps asserting that the post-import plan is an in-place update (not replace) and the subsequent plan is a no-op, covering both `password` and `password_wo` flows

Fixes #196