### PR TITLE
sendgrid_sso_teammate: create silently drops subuser_access when a scope is invalid

### DIFF
--- a/docs/resources/sso_teammate.md
+++ b/docs/resources/sso_teammate.md
@@ -57,7 +57,7 @@ Required:
 
 Optional:
 
-- `scopes` (Set of String) Add or remove permissions that the Teammate can access on behalf of the Subuser. See [Teammate Permissions](https://www.twilio.com/docs/sendgrid/ui/account-and-settings/teammate-permissions) for a complete list of available scopes. You should not include this property in the request when the `permission_type` property is set to `admin` — administrators have full access to the specified Subuser.
+- `scopes` (Set of String) Add or remove permissions that the Teammate can access on behalf of the Subuser. See [Teammate Permissions](https://www.twilio.com/docs/sendgrid/ui/account-and-settings/teammate-permissions) for a complete list of available scopes. You should not include this property in the request when the `permission_type` property is set to `admin` — administrators have full access to the specified Subuser. `sender_verification_legacy` is not valid here even though SendGrid assigns it automatically at the parent account level: including it makes SendGrid discard the whole `subuser_access` block without reporting an error, creating the Teammate with default scopes only.
 
 ## Import
 

--- a/internal/provider/sso_teammate_resource.go
+++ b/internal/provider/sso_teammate_resource.go
@@ -25,6 +25,14 @@ import (
 	"github.com/kenzo0107/terraform-provider-sendgrid/flex"
 )
 
+// subuserAccessInvalidScopeReason explains a SendGrid behaviour that is easy to hit and hard to
+// diagnose: sender_verification_legacy is assigned automatically to teammates at the parent
+// account level, so it reads as an ordinary scope, but it is not valid inside subuser_access.
+const subuserAccessInvalidScopeReason = "This scope is assigned automatically at the parent " +
+	"account level and is not valid inside subuser_access. SendGrid discards the whole " +
+	"subuser_access block without reporting an error when it is present, creating the teammate " +
+	"with default scopes only"
+
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = &ssoTeammateResource{}
 var _ resource.ResourceWithImportState = &ssoTeammateResource{}
@@ -218,7 +226,12 @@ For more detailed information, please see the [SendGrid documentation](https://d
 						"scopes": schema.SetAttribute{
 							ElementType:         types.StringType,
 							Optional:            true,
-							MarkdownDescription: "Add or remove permissions that the Teammate can access on behalf of the Subuser. See [Teammate Permissions](https://www.twilio.com/docs/sendgrid/ui/account-and-settings/teammate-permissions) for a complete list of available scopes. You should not include this property in the request when the `permission_type` property is set to `admin` — administrators have full access to the specified Subuser.",
+							MarkdownDescription: "Add or remove permissions that the Teammate can access on behalf of the Subuser. See [Teammate Permissions](https://www.twilio.com/docs/sendgrid/ui/account-and-settings/teammate-permissions) for a complete list of available scopes. You should not include this property in the request when the `permission_type` property is set to `admin` — administrators have full access to the specified Subuser. `sender_verification_legacy` is not valid here even though SendGrid assigns it automatically at the parent account level: including it makes SendGrid discard the whole `subuser_access` block without reporting an error, creating the Teammate with default scopes only.",
+							Validators: []validator.Set{
+								setvalidator.ValueStringsAre(
+									stringNoneOf(subuserAccessInvalidScopeReason, "sender_verification_legacy"),
+								),
+							},
 						},
 					},
 				},
@@ -308,7 +321,39 @@ func (r *ssoTeammateResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	saArray := fromOutputSubuserAccessArray(o.SubuserAccess)
+	// NOTE: The creation API answers 201 with subuser_access omitted when it discarded the value, so
+	//       an empty response here means the teammate was created without the requested access.
+	//       Report that instead of recording the resource as if the request had been applied.
+	if !o.IsAdmin && len(data.SubuserAccess) > 0 && len(o.SubuserAccess) == 0 {
+		// NOTE: The teammate exists in SendGrid at this point. Save it before reporting the error so
+		//       Terraform tracks it as tainted and replaces it on the next apply, rather than failing
+		//       on a duplicate that has to be deleted or imported by hand.
+		resp.Diagnostics.Append(resp.State.Set(ctx, &ssoTeammateResourceModel{
+			ID:        types.StringValue(o.Email),
+			Email:     types.StringValue(o.Email),
+			IsAdmin:   types.BoolValue(o.IsAdmin),
+			FirstName: types.StringValue(o.FirstName),
+			LastName:  types.StringValue(o.LastName),
+			Username:  types.StringValue(o.Email),
+		})...)
+		resp.Diagnostics.AddError(
+			"Creating SSO teammate",
+			fmt.Sprintf(
+				"SendGrid created teammate %s but did not apply the requested subuser_access. It "+
+					"does this without reporting an error when subuser_access contains a scope that "+
+					"is not valid for a subuser, and the teammate is left holding default scopes "+
+					"only. Check the scopes listed in subuser_access and apply again.",
+				o.Email,
+			),
+		)
+		return
+	}
+
+	// NOTE: The creation API normalizes the subuser access it echoes back, sorting the scopes and
+	//       omitting them altogether for admin entries, so the echo cannot be stored as-is. Adopt the
+	//       planned value, which the check above has confirmed SendGrid applied. Drift against
+	//       SendGrid is still detected by the next Read.
+	saArray := data.SubuserAccess
 	// NOTE: The teammate read API returns subuser access with admin permissions to all subusers when the user is admin,
 	//       causing a discrepancy with the subuser access specified in the resource and resulting in an error.
 	if o.IsAdmin {

--- a/internal/provider/validator_string_none_of.go
+++ b/internal/provider/validator_string_none_of.go
@@ -1,0 +1,58 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// stringNoneOf rejects a fixed set of values and states why. The generic "must be none of"
+// wording tells practitioners which value was rejected but not what goes wrong when it is used,
+// which matters when the API accepts the request and discards part of it instead of failing.
+func stringNoneOf(reason string, items ...string) validatorStringNoneOf {
+	itemMap := map[string]struct{}{}
+	for _, i := range items {
+		itemMap[i] = struct{}{}
+	}
+	return validatorStringNoneOf{
+		Items:  itemMap,
+		Reason: reason,
+	}
+}
+
+type validatorStringNoneOf struct {
+	Items  map[string]struct{}
+	Reason string
+}
+
+func (v validatorStringNoneOf) keys() (out []string) {
+	for k := range v.Items {
+		out = append(out, k)
+	}
+	return
+}
+
+func (v validatorStringNoneOf) Description(ctx context.Context) string {
+	return fmt.Sprintf("Item must not be one of %s", strings.Join(v.keys(), " "))
+}
+
+func (v validatorStringNoneOf) MarkdownDescription(ctx context.Context) string {
+	return fmt.Sprintf("Item must not be one of `%s`", strings.Join(v.keys(), "` `"))
+}
+
+func (v validatorStringNoneOf) ValidateString(ctx context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsUnknown() || req.ConfigValue.IsNull() {
+		return
+	}
+
+	if _, ok := v.Items[req.ConfigValue.ValueString()]; ok {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid value provided",
+			fmt.Sprintf("%s, got: %s.", v.Reason, req.ConfigValue.ValueString()),
+		)
+		return
+	}
+}

--- a/internal/provider/validator_string_none_of_test.go
+++ b/internal/provider/validator_string_none_of_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestValidatorStringNoneOf(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		value       types.String
+		wantError   bool
+		wantInError string
+	}{
+		"rejected value reports the reason": {
+			value:       types.StringValue("sender_verification_legacy"),
+			wantError:   true,
+			wantInError: "not valid inside subuser_access",
+		},
+		"rejected value names itself": {
+			value:       types.StringValue("sender_verification_legacy"),
+			wantError:   true,
+			wantInError: "sender_verification_legacy",
+		},
+		"allowed value passes": {
+			value:     types.StringValue("marketing_campaigns.create"),
+			wantError: false,
+		},
+		"null is left to the schema": {
+			value:     types.StringNull(),
+			wantError: false,
+		},
+		"unknown is deferred to apply": {
+			value:     types.StringUnknown(),
+			wantError: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			req := validator.StringRequest{
+				Path:        path.Root("subuser_access").AtListIndex(0).AtName("scopes"),
+				ConfigValue: test.value,
+			}
+			resp := &validator.StringResponse{}
+
+			stringNoneOf(subuserAccessInvalidScopeReason, "sender_verification_legacy").
+				ValidateString(context.Background(), req, resp)
+
+			if got := resp.Diagnostics.HasError(); got != test.wantError {
+				t.Fatalf("got error = %v, want %v (%v)", got, test.wantError, resp.Diagnostics)
+			}
+			if !test.wantError {
+				return
+			}
+			if detail := resp.Diagnostics.Errors()[0].Detail(); !strings.Contains(detail, test.wantInError) {
+				t.Errorf("error detail %q does not contain %q", detail, test.wantInError)
+			}
+		})
+	}
+}


### PR DESCRIPTION
> **Update:** I have since found the root cause, and it is not what this diff assumes.
> **Please do not merge the diff as it stands** — it would hide the failure described below.
> The report is still worth having, and I am happy to rework the change (see "Suggested fix").

### Root cause

`POST /v3/sso/teammates` silently discards `subuser_access` when any scope inside it is invalid.
No error, no `errors` array — a 2xx response with `subuser_access` omitted, and a teammate created
with SendGrid's default scopes only.

The scope that triggered it for me was `sender_verification_legacy`. SendGrid auto-assigns it to
teammates at the parent account level, so it looks legitimate, but it is not accepted inside
`subuser_access.scopes`.

The two endpoints disagree about how to handle this:

| request | invalid scope in `subuser_access` |
|---|---|
| `PATCH /v3/sso/teammates/{email}` | `HTTP 500 {"errors":[{"message":"invalid scopes provided"}]}` |
| `POST /v3/sso/teammates` | `2xx`, `subuser_access` dropped from both the response and the account |

Verified against a live account by bisecting the scope list over `PATCH`:

| attempt | scopes | result |
|---|---|---|
| original list | 47 | `HTTP 500 invalid scopes provided` |
| known-good list from another teammate | 36 | `HTTP 200` |
| + `marketing_campaigns.*`, `templates.*`, `templates.versions.*` | 44 | `HTTP 200` |
| + `sender_verification_legacy` only | 50 | `HTTP 500` |
| + `marketing.read` only | 50 | `HTTP 200` |
| original list minus `sender_verification_legacy` | 46 | `HTTP 200`, applied and read back |

### How it surfaces in the provider

`Create` stores whatever the create call returned:

```go
saArray := fromOutputSubuserAccessArray(o.SubuserAccess)
```

`fromOutputSubuserAccessArray` returns `nil` for the empty response, so an attribute the plan
declared comes back null and the framework aborts with:

```
Error: Provider produced inconsistent result after apply

When applying changes to sendgrid_sso_teammate.example, provider
"provider[\"registry.terraform.io/kenzo0107/sendgrid\"]" produced an
unexpected new value: .subuser_access: was
cty.ListVal([]cty.Value{cty.ObjectVal(map[string]cty.Value{"id":cty.NumberIntVal(12345678),
"permission_type":cty.StringVal("restricted"), "scopes":cty.SetVal(...)})}), but now null.

This is a bug in the provider, which should be reported in the provider's own
issue tracker.
```

The resource is left tainted, the teammate exists in SendGrid with the wrong permissions, and the
message points at the provider rather than at the offending scope. Reproduced on 2.5.1;
`sso_teammate_resource.go` has not changed since v2.2.1, so 3.0.0 behaves the same.

`Update` reads the same field from `UpdateSSOTeammate`, but `PATCH` fails loudly first, so that
path reports the real problem already.

### Suggested fix

Since the empty `subuser_access` in the create response is accurate — SendGrid really did not
apply it — the provider should say so instead of letting the framework produce the message above.
Roughly:

```go
saArray := fromOutputSubuserAccessArray(o.SubuserAccess)
if len(data.SubuserAccess) > 0 && len(saArray) == 0 && !o.IsAdmin {
    resp.Diagnostics.AddError(
        "Creating SSO teammate",
        "SendGrid accepted the request but did not apply subuser_access, which it does silently "+
            "when subuser_access contains a scope that is not valid for a subuser "+
            "(sender_verification_legacy is one such scope). The teammate was created with default "+
            "scopes only. Verify the scopes in subuser_access and re-apply.",
    )
    return
}
```

That keeps the resource from being recorded as if it succeeded, and names the likely cause.

The diff currently on this branch does the opposite — it adopts the planned value when the
response is empty, which was written before I understood the cause. It makes the apply succeed
while the teammate silently keeps default scopes, so it should not be merged.

Tell me which you would prefer and I will push it:

- the error above (my suggestion)
- validating scopes against a known-invalid-for-subuser list at plan time
- nothing in code, and this stays a bug report

I can drop the current commits either way.
