### PR TITLE
Skip acceptance tests for Dependabot pull_request runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,11 @@ jobs:
   # Run acceptance tests in a matrix with Terraform CLI versions
   test:
     name: Terraform Provider Acceptance Tests
+    # Dependabot-triggered pull_request runs don't get repository secrets,
+    # so SENDGRID_API_KEY resolves empty and every API call fails with
+    # "authorization required". Skip until the PR is reviewed and merged,
+    # when the scheduled run against main exercises the real API key.
+    if: github.actor != 'dependabot[bot]'
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 30


### PR DESCRIPTION
## Summary
- GitHub Actions doesn't pass repository secrets to `pull_request` runs triggered by Dependabot, so `SENDGRID_API_KEY` resolves to an empty string
- As a result, the `Terraform Provider Acceptance Tests` job failed every test with `authorization required` / `unauthorized` (e.g. the CI failure on #203)
- Skip the job when `github.actor == 'dependabot[bot]'` to avoid these meaningless failures
- After merge, the existing scheduled run against `main` still exercises the real API key

## Test plan
- [ ] Confirm `Build` / `generate` jobs pass on this PR
- [ ] Confirm the `Terraform Provider Acceptance Tests` job still runs normally on this PR (non-Dependabot actor)
- [ ] Confirm the job is skipped on the next Dependabot PR after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)